### PR TITLE
XT-3095: Allow enabling review feature at generation time

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,16 +190,37 @@ e.g.
 ```shell
 PYTHONPATH=/path/to/Arelle:/path/to/ixbrl-viewer ./samples/build-viewer.py --out out-dir --package-dir /my/packages/ ixds-dir
 ```
+# Optional Features
+Some features are disabled by default but can be enabled at generation time or with query parameters.
 
-## Review mode
+To enable features:
+- Via CLI: `--viewer-feature-{feature name}`
+- Via query parameter:`?{feature name}=true`
+
+Features enabled by CLI/JSON can be disabled by query parameter via `?{feature name}=false`.
+Note that *any other value* besides "false" (case-sensitive) will *enable* the feature.
+This will override any enabling query parameters, so `?review=true&review=false&review=true` would result in the 'review' feature being disabled.
+
+This table uses the 'review' feature as an example to demonstrate how these options interact:
+
+| CLI/JSON | Query Param | Result     |
+|----------|-------------|------------|
+| `unset`  | `unset`     | `disabled` |
+| `unset`  | `true`      | `enabled`  |
+| `unset`  | `false`     | `disabled` |
+| `review` | `unset`     | `enabled`  |
+| `review` | `true`      | `enabled`  |
+| `review` | `false`     | `disabled` |
+
+## Feature: Review Mode
 ![ixbrl-viewer](https://raw.githubusercontent.com/Arelle/ixbrl-viewer/master/examples/review-mode.png)
 
 A review mode is available that is intended to assist in reviewing partially tagged or incomplete documents.
 This mode replaces the namespace-based highlighting with optional highlighting based on untagged numbers and/or dates.
 
-To enable review mode while viewing a document, include a "review" entry in the URL query string.
-
-Example: `file://path-to-your-document/ixbrl-report-viewer.html?review`
+| CLI/JSON                  | Query Param    |
+|---------------------------|----------------|
+| `--viewer-feature-review` | `?review=true` |
 
 
 ## Running tests

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from typing import Optional, Union
 
 import pycountry
-from arelle import XbrlConst
+from arelle import ModelXbrl, XbrlConst
 from arelle.ModelDocument import Type
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelValue import QName, INVALIDixVALUE
@@ -37,6 +37,10 @@ LINK_QNAME_TO_LOCAL_DOCUMENTS_LINKBASE_TYPE = {
 }
 
 WIDER_NARROWER_ARCROLE = 'http://www.esma.europa.eu/xbrl/esef/arcrole/wider-narrower'
+
+VIEWER_FEATURES_AND_DESCRIPTIONS = {
+    "review": "Enables highlighting of untagged numbers and dates.",
+}
 
 class NamespaceMap:
     """
@@ -82,7 +86,7 @@ class IXBRLViewerBuilderError(Exception):
 
 class IXBRLViewerBuilder:
 
-    def __init__(self, dts, basenameSuffix = ''):
+    def __init__(self, dts: ModelXbrl, basenameSuffix: str = ''):
         self.nsmap = NamespaceMap()
         self.roleMap = NamespaceMap()
         self.dts = dts
@@ -90,9 +94,17 @@ class IXBRLViewerBuilder:
             "concepts": {},
             "languages": {},
             "facts": {},
+            "features": [],
         }
         self.footnoteRelationshipSet = ModelRelationshipSet(dts, "XBRL-footnotes")
         self.basenameSuffix = basenameSuffix
+
+    def enableFeature(self, featureName: str):
+        if featureName in self.taxonomyData["features"]:
+            return
+        assert featureName in VIEWER_FEATURES_AND_DESCRIPTIONS, \
+            f'Given feature name `{featureName}` does not match any defined features: {VIEWER_FEATURES_AND_DESCRIPTIONS.keys()}'
+        self.taxonomyData["features"].append(featureName)
 
     def outputFilename(self, filename):
         (base, ext) = os.path.splitext(filename)

--- a/iXBRLViewerPlugin/viewer/src/js/index.js
+++ b/iXBRLViewerPlugin/viewer/src/js/index.js
@@ -4,9 +4,7 @@ import $ from 'jquery'
 import { iXBRLViewer } from "./ixbrlviewer.js";
 
 $(() => {
-    const urlParams = new URLSearchParams(window.location.search);
     const iv = new iXBRLViewer({
-        reviewMode: urlParams.has('review'),
         showValidationWarningOnStart: true
     });
     iv.load();

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -190,7 +190,7 @@ export class Inspector {
         const iv = this._iv;
         this._toolbarMenu.reset();
         this._toolbarMenu.addCheckboxItem(i18next.t("toolbar.xbrlElements"), (checked) => this.highlightAllTags(checked), "highlight-tags", null, this._iv.options.highlightTagsOnStartup);
-        if (iv.options.reviewMode) {
+        if (iv.isReviewModeEnabled()) {
             this._toolbarMenu.addCheckboxItem("Untagged Numbers", function (checked) {
                 const body = iv.viewer.contents().find("body");
                 if (checked) {
@@ -217,7 +217,7 @@ export class Inspector {
     buildHighlightKey() {
         $(".highlight-key .items").empty();
         let key;
-        if (this._iv.options.reviewMode) {
+        if (this._iv.isReviewModeEnabled()) {
             key = [
                 "XBRL Elements",
                 "Untagged Numbers",

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -197,12 +197,12 @@ iXBRLViewer.prototype.load = function () {
     var iv = this;
     var inspector = this.inspector;
 
-    // We need to parse JSON first so that we can determine feature enablement before loading begins.
-    const taxonomyData = iv._getTaxonomyData();
-    const parsedTaxonomyData = taxonomyData && JSON.parse(taxonomyData);
-    iv.setFeatures((parsedTaxonomyData && parsedTaxonomyData["features"]) || [], window.location.search);
-
     setTimeout(function () {
+
+        // We need to parse JSON first so that we can determine feature enablement before loading begins.
+        const taxonomyData = iv._getTaxonomyData();
+        const parsedTaxonomyData = taxonomyData && JSON.parse(taxonomyData);
+        iv.setFeatures((parsedTaxonomyData && parsedTaxonomyData["features"]) || [], window.location.search);
 
         iv._loadInspectorHTML();
         var iframes;

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -96,12 +96,14 @@ iXBRLViewer.prototype.setFeatures = function(featureNames, queryString) {
     });
 
     // Gather results in _features set
-    iv._features = new Set();
-    Object.keys(featureMap).forEach(f => {
-        if (featureMap[f]) {
-            iv._features.add(f);
+    if (iv._features.size > 0) {
+        iv._features = new Set();
+    }
+    for (const [feature, enabled] of Object.entries(featureMap)) {
+        if (enabled) {
+            iv._features.add(feature);
         }
-    });
+    }
 }
 
 iXBRLViewer.prototype.isFeatureEnabled = function (featureName) {

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -14,7 +14,6 @@ export function iXBRLViewer(options) {
     options = options || {};
     const defaults = {
         continuationElementLimit: 10000,
-        reviewMode: false,
         showValidationWarningOnStart: false,
     }
     this.options = {...defaults, ...options};
@@ -162,7 +161,7 @@ iXBRLViewer.prototype._reparentDocument = function () {
      * the body tag in an HTML DOM, so move them so that they are */
     $('body script').appendTo($('body'));
     const iframeBody = $(iframe).contents().find('body');
-    if (this.options.reviewMode) {
+    if (this.isReviewModeEnabled()) {
         iframeBody.addClass('review');
     }
     $('body').children().not("script").not('#ixv').not(iframeContainer).appendTo(iframeBody);

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
@@ -1,0 +1,80 @@
+// See COPYRIGHT.md for copyright information
+
+import {iXBRLViewer} from "./ixbrlviewer";
+describe("Feature enablement", () => {
+    var viewer = null;
+    beforeAll(() => {
+        viewer = new iXBRLViewer({})
+    });
+
+    test("Query parameter with no value results in enablement", () => {
+        viewer.setFeatures([], 'a')
+        expect(viewer._features).toEqual(new Set(['a']));
+        expect(viewer.isFeatureEnabled('a')).toBeTruthy();
+    });
+
+    test("Excluded from JSON, excluded from query", () => {
+        viewer.setFeatures([], '')
+        expect(viewer._features).toEqual(new Set([]));
+        expect(viewer.isFeatureEnabled('a')).toBeFalsy();
+    });
+
+    test("Excluded from JSON, enabled in query", () => {
+        viewer.setFeatures([], 'a=true')
+        expect(viewer._features).toEqual(new Set(['a']));
+        expect(viewer.isFeatureEnabled('a')).toBeTruthy();
+    });
+
+    test("Excluded from JSON, disabled in query", () => {
+        viewer.setFeatures([], 'a=false')
+        expect(viewer._features).toEqual(new Set([]));
+        expect(viewer.isFeatureEnabled('a')).toBeFalsy();
+    });
+
+    test("Excluded from JSON, enabled and disabled in query", () => {
+        viewer.setFeatures([], 'a=true&a=false&a')
+        expect(viewer._features).toEqual(new Set([]));
+        expect(viewer.isFeatureEnabled('a')).toBeFalsy();
+    });
+
+    test("Included in JSON, excluded from query", () => {
+        viewer.setFeatures(['a'], '')
+        expect(viewer._features).toEqual(new Set(['a']));
+        expect(viewer.isFeatureEnabled('a')).toBeTruthy();
+    });
+
+    test("Included in JSON, enabled in query", () => {
+        viewer.setFeatures(['a'], 'a=true')
+        expect(viewer._features).toEqual(new Set(['a']));
+        expect(viewer.isFeatureEnabled('a')).toBeTruthy();
+    });
+
+    test("Included in JSON, disabled in query", () => {
+        viewer.setFeatures(['a'], 'a=false')
+        expect(viewer._features).toEqual(new Set([]));
+        expect(viewer.isFeatureEnabled('a')).toBeFalsy();
+    });
+
+    test("Included in JSON, enabled and disabled in query", () => {
+        viewer.setFeatures(['a'], 'a=true&a=false&a')
+        expect(viewer._features).toEqual(new Set([]));
+        expect(viewer.isFeatureEnabled('a')).toBeFalsy();
+    });
+});
+
+describe("Review mode enablement", () => {
+    var viewer = null;
+    beforeAll(() => {
+        viewer = new iXBRLViewer({})
+    });
+
+    test("Review mode enabled", () => {
+        viewer.setFeatures(['review'], '')
+        expect(viewer.isReviewModeEnabled()).toBeTruthy();
+    });
+
+    test("Review mode disabled", () => {
+        viewer.setFeatures(['a'], '')
+        expect(viewer.isReviewModeEnabled()).toBeFalsy();
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -73,7 +73,7 @@ export class Viewer {
                         for (const [docIndex, iframe] of viewer._iframes.toArray().entries()) {
                             const body = $(iframe).contents().find("body").get(0);
                             await viewer._iv.pluginPromise('preProcessiXBRL', body, docIndex);
-                            if (viewer._iv.options.reviewMode) {
+                            if (viewer._iv.isReviewModeEnabled()) {
                                 await new Promise((resolve, _) => {
                                     viewer._iv.setProgress("Finding untagged numbers").then(() => {
                                         // Temporarily hide all children of "body" to avoid constant

--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -23,7 +23,7 @@ import glob
 import argparse
 import iXBRLViewerPlugin.iXBRLViewer
 from arelle.plugin import inlineXbrlDocumentSet
-from iXBRLViewerPlugin import generateViewer
+from iXBRLViewerPlugin import generateViewer, getFeaturesFromOptions, VIEWER_FEATURES_AND_DESCRIPTIONS
 
 class CntlrCreateViewer(Cntlr.Cntlr):
 
@@ -40,7 +40,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
                 self.addToLog("Failed to load package", messageCode="error", file=p)
         PackageManager.rebuildRemappings(self)
     
-    def createViewer(self, f, scriptUrl=None, outPath=None, useStubViewer=False):
+    def createViewer(self, f, scriptUrl=None, outPath=None, useStubViewer=False, features=None):
         if os.path.isdir(f):
             files = glob.glob(os.path.join(f, "*.xhtml")) + glob.glob(os.path.join(f, "*.html")) + glob.glob(os.path.join(f, "*.htm"))
             files.sort()
@@ -56,7 +56,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
         self.modelManager.validate()
 
         try:
-            generateViewer(self, outPath, scriptUrl, showValidationMessages=True, useStubViewer=useStubViewer)
+            generateViewer(self, outPath, scriptUrl, showValidationMessages=True, useStubViewer=useStubViewer, features=features)
         except iXBRLViewerPlugin.iXBRLViewer.IXBRLViewerBuilderError as e:
             print(e.message)
             sys.exit(1)
@@ -70,6 +70,11 @@ parser.add_argument("--use-stub-viewer",
                     help="Use stub viewer for faster loading of inspector (requires web server)")
 parser.add_argument('files', metavar='FILES', nargs='+',
                     help='Files to process')
+featureGroup = parser.add_argument_group('Viewer Features')
+for featureName, featureDescription in VIEWER_FEATURES_AND_DESCRIPTIONS.items():
+    arg = f'--viewer-feature-{featureName}'
+    featureGroup.add_argument(arg, arg.lower(), action="store_true", default=False, help=featureDescription)
+
 args = parser.parse_args()
 
 cntlr = CntlrCreateViewer()
@@ -91,4 +96,9 @@ if args.package_dir:
     cntlr.loadPackagesFromDir(args.package_dir)
 
 for f in args.files:
-    cntlr.createViewer(f, outPath = args.out, scriptUrl = args.viewer_url, useStubViewer = args.use_stub_viewer)
+    cntlr.createViewer(
+        f,
+        outPath=args.out,
+        scriptUrl=args.viewer_url,
+        useStubViewer=args.use_stub_viewer,
+        features=getFeaturesFromOptions(args))

--- a/tests/puppeteer/tests/highlight.test.js
+++ b/tests/puppeteer/tests/highlight.test.js
@@ -135,7 +135,7 @@ describe('ixbrl-viewer:', () => {
     });
 
     test('Highlight Test - Review', async () => {
-        await viewerPage.navigateToViewer('highlights.zip', '?review');
+        await viewerPage.navigateToViewer('highlights.zip', '?review=true');
 
         // Assert on load values are not highlighted
         await viewerPage.docFrame.assertHighlights([

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -585,6 +585,19 @@ class TestIXBRLViewer(unittest.TestCase):
         self.assertEqual(facts["fact_id2"]["a"]["u"], "iso4217:USD")
         self.assertEqual(facts["fact_id3"]["a"]["u"], None)
 
+    def test_enableFeature_valid(self):
+        """
+        Enable a defined feature
+        """
+        self.builder_1.enableFeature('review')
+        self.assertEqual(self.builder_1.taxonomyData["features"], ['review'])
+
+    def test_enableFeature_invalid(self):
+        """
+        Attempt to enable an undefined feature
+        """
+        with self.assertRaisesRegex(AssertionError, rf'^Given feature name `unknown` does not match any defined features'):
+            self.builder_1.enableFeature('unknown')
 
     def test_xhtmlNamespaceHandling(self):
         # Check the prefix used for our inserted script tags
@@ -626,4 +639,3 @@ class TestIXBRLViewer(unittest.TestCase):
             self.assertEqual(body[2].prefix, None)
             self.assertEqual(body[2].attrib.get('type'), 'application/x.ixbrl-viewer+json')
             self.assertEqual(body[3].text, 'END IXBRL VIEWER EXTENSIONS')
-


### PR DESCRIPTION
#### Reason for change
Closes #519 

#### Description of change
- Generate command line options for each feature, i.e. `--viewer-feature-review`
- Serialize enabled features in `features` array in JSON
- On load, use JSON `features` and query string to determine enablement
- Document optional features and review mode in README

#### Steps to Test

- Test combinations of:
  - Generating via Arelle CLI, build-viewer.py
  - With  `--viewer-feature-review`, without `--viewer-feature-review`
  - With `?review=true`, With `?review=false`
- Confirm expected outcome based on:

| CLI/JSON | Query Param | Result     |
|----------|-------------|------------|
| `unset`  | `unset`     | `disabled` |
| `unset`  | `true`      | `enabled`  |
| `unset`  | `false`     | `disabled` |
| `review` | `unset`     | `enabled`  |
| `review` | `true`      | `enabled`  |
| `review` | `false`     | `disabled` |



**review**:
@Workiva/xt
@paulwarren-wk
