### PR TITLE
XT-3123: Add 'review' class separate from stub viewer logic

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -163,9 +163,6 @@ iXBRLViewer.prototype._reparentDocument = function () {
      * the body tag in an HTML DOM, so move them so that they are */
     $('body script').appendTo($('body'));
     const iframeBody = $(iframe).contents().find('body');
-    if (this.isReviewModeEnabled()) {
-        iframeBody.addClass('review');
-    }
     $('body').children().not("script").not('#ixv').not(iframeContainer).appendTo(iframeBody);
 
     /* Move all attributes on the body tag to the new body */

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -75,11 +75,12 @@ export class Viewer {
                             await viewer._iv.pluginPromise('preProcessiXBRL', body, docIndex);
                             if (viewer._iv.isReviewModeEnabled()) {
                                 await new Promise((resolve, _) => {
-                                    viewer._iv.setProgress("Finding untagged numbers").then(() => {
+                                    viewer._iv.setProgress("Finding untagged numbers and dates").then(() => {
                                         // Temporarily hide all children of "body" to avoid constant
                                         // re-layouts when wrapping untagged numbers
                                         const children = $(body).children(':visible');
                                         children.hide();
+                                        $(body).addClass("review");
                                         viewer._wrapUntaggedNumbers($(body), docIndex, false);
                                         children.show();
                                         resolve();


### PR DESCRIPTION
#### Reason for change
Resolves #538 

#### Description of change
Code that added `review` class to iframe body (which overrides highlighting colors) was only run when stub viewer wasn't enabled. This PR moves the addition of the `review` class alongside the review-specific untagged highlighting code.

#### Steps to Test

Generate viewer with both stub viewer and review mode enabled, confirm highlighting looks as expected.

**review**:
@Arelle/arelle
@paulwarren-wk
