### PR TITLE
Make the download filing documents link look like a normal menu item

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/menu.js
+++ b/iXBRLViewerPlugin/viewer/src/js/menu.js
@@ -46,11 +46,11 @@ export class Menu {
     addDownloadButton(name, filename) {
         const menu = this;
         const item = $('<a></a>')
+                .addClass("item")
                 .attr({
                     href: filename})
-                .prepend($('<input type="button">')
-                        .prop("value", name)
-                        .click(() => menu.close()));
+                .text(name)
+                .click(() => menu.close());
         this._add(item);
     }
 

--- a/iXBRLViewerPlugin/viewer/src/less/menu.less
+++ b/iXBRLViewerPlugin/viewer/src/less/menu.less
@@ -80,6 +80,7 @@
             }
           }
         }
+
         a.item {
           display: block;
           color: @text;

--- a/iXBRLViewerPlugin/viewer/src/less/menu.less
+++ b/iXBRLViewerPlugin/viewer/src/less/menu.less
@@ -2,7 +2,7 @@
 
 @import url("form-controls.less");
 
-#ixv {
+#ixv #inspector {
   .menu {
     position: absolute;
     right: 0;
@@ -78,6 +78,14 @@
               top: 1.1rem;
               left: 1rem;
             }
+          }
+        }
+        a.item {
+          display: block;
+          color: @text;
+
+          &:hover {
+            text-decoration: none;
           }
         }
       }


### PR DESCRIPTION
#### Reason for change

The "Download filing documents" menu option was using an HTML button.  I'm not sure if there was a reason for this, but in my view it looks out of place.  This PR re-styles it like a normal menu item.

![image](https://github.com/Arelle/ixbrl-viewer/assets/45077928/9774f93a-8be0-47a6-8c10-3507928c2ef5)

Also fixes #541 

#### Description of change

Changes "Download filing documents" menu option to be a normal menu item, created using well-formed XHTML.

#### Steps to Test

Create a viewer from a ZIP file, such that the "download filing documents" menu item is present.  Check that the styling of the menu item is now the same as other menu items.

**review**:
@Arelle/arelle
@paulwarren-wk
