### PR TITLE
Add an option to provide URL to download filing documents.

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -70,6 +70,10 @@ def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
                       default="",
                       dest="viewerBasenameSuffix",
                       help="Suffix for basename of viewer files")
+    parser.add_option("--package-download-url",
+                      action="store",
+                      dest="packageDownloadURL",
+                      help="URL where the original report package can be downloaded.  This will be available to the user as a download link in the viewer.")
     parser.add_option("--zip-viewer-output",
                       action="store_true",
                       default=False,
@@ -90,7 +94,8 @@ def generateViewer(
         showValidationMessages: bool = False,
         useStubViewer: bool = False,
         zipViewerOutput: bool = False,
-        features: Optional[list[str]] = None):
+        features: Optional[list[str]] = None,
+        packageDownloadURL: str = None):
     """
     Generate and save a viewer at the given destination (file, directory, or in-memory file) with the given viewer URL.
     If the viewer URL is a location on the local file system, a copy will be placed included in the output destination.
@@ -134,7 +139,7 @@ def generateViewer(
             if features:
                 for feature in features:
                     viewerBuilder.enableFeature(feature)
-            iv = viewerBuilder.createViewer(scriptUrl=viewerURL, showValidations=showValidationMessages, useStubViewer=useStubViewer)
+            iv = viewerBuilder.createViewer(scriptUrl=viewerURL, showValidations=showValidationMessages, useStubViewer=useStubViewer, packageDownloadURL=packageDownloadURL)
             if iv is not None:
                 iv.save(out, zipOutput=zipViewerOutput, copyScriptPath=copyScriptPath)
     except IXBRLViewerBuilderError as ex:
@@ -172,7 +177,8 @@ def iXBRLViewerCommandLineXbrlRun(cntlr, options, *args, **kwargs):
         options.validationMessages,
         options.useStubViewer,
         options.zipViewerOutput,
-        getFeaturesFromOptions(options)
+        getFeaturesFromOptions(options),
+        options.packageDownloadURL,
     )
 
 

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -379,7 +379,7 @@ class IXBRLViewerBuilder:
         with open(os.path.join(os.path.dirname(__file__),"stubviewer.html")) as fin:
             return etree.parse(fin)
 
-    def createViewer(self, scriptUrl: str = DEFAULT_VIEWER_PATH, useStubViewer: bool = False, showValidations: bool = True) -> Optional[iXBRLViewer]:
+    def createViewer(self, scriptUrl: str = DEFAULT_VIEWER_PATH, useStubViewer: bool = False, showValidations: bool = True, packageDownloadURL: str = None) -> Optional[iXBRLViewer]:
         """
         Create an iXBRL file with XBRL data as a JSON blob, and script tags added.
         :param scriptUrl: The `src` value of the script tag that loads the viewer script.
@@ -437,7 +437,10 @@ class IXBRLViewerBuilder:
         else:
             xmlDocument = deepcopy(dts.modelDocument.xmlDocument)
             iv.addFile(iXBRLViewerFile('xbrlviewer.html', xmlDocument))
-        if os.path.dirname(self.dts.modelDocument.filepath).endswith('.zip'):
+
+        if packageDownloadURL is not None:
+            self.taxonomyData["filingDocuments"] = packageDownloadURL
+        elif os.path.dirname(self.dts.modelDocument.filepath).endswith('.zip'):
             filingDocZipPath = os.path.dirname(self.dts.modelDocument.filepath)
             filingDocZipName = os.path.basename(filingDocZipPath)
             iv.addFilingDoc(filingDocZipPath)


### PR DESCRIPTION
#### Reason for change

The "download filing documents" feature uses the name of the ZIP file that the viewer was built from as the package to download, and copies the ZIP file into the same directory as the generated viewer.

For filings.xbrl.org, the filing already has a public URL, and we don't want to make another copy of the ZIP; we just want the download link in the viewer to link to the existing URL.

#### Description of change

This PR provides a `--package-download-url` option.  If specified, this overrides the current logic for adding the `filingDocuments` property to the JSON, and does not attempt to take a copy of the ZIP file.

#### Steps to Test

Create a viewer from the command line, and specify a URL using `--package-download-url`.  This can by absolutely any URL, but for realism a URL to a ZIP file would be most suitable.  Check that the "download filing documents" link is present in the resulting viewer, and that clicking on it opens the provided URL.

**review**:
@Arelle/arelle
@paulwarren-wk
