### PR TITLE
XT-3096: Integrate viewer url and feature options into the tools menu

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -253,6 +253,9 @@ class iXBRLViewerLocalViewer(LocalViewer):
 
 def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
     """ run iXBRL Viewer using GUI interactions for a single instance or testcases """
+    if not cntlr.config.setdefault(CONFIG_LAUNCH_ON_LOAD, DEFAULT_LAUNCH_ON_LOAD):
+        # Don't run on launch if the option has been disabled
+        return
     try:
         import webbrowser
         global tempViewer

--- a/iXBRLViewerPlugin/constants.py
+++ b/iXBRLViewerPlugin/constants.py
@@ -2,4 +2,27 @@
 
 import os
 
+from .featureConfig import FeatureConfig
+
+CONFIG_FEATURE_PREFIX = 'iXBRLViewerFeature_'
+CONFIG_FILE_DIRECTORY = 'iXBRLViewerFileDir'
+CONFIG_LAUNCH_ON_LOAD = 'iXBRLViewerLaunchOnLoad'
+CONFIG_OUTPUT_FILE = 'iXBRLViewerOutputFile'
+CONFIG_SCRIPT_URL = 'iXBRLViewerScriptURL'
+CONFIG_ZIP_OUTPUT = 'iXBRLViewerZipOutput'
+
+DEFAULT_LAUNCH_ON_LOAD = True
+DEFAULT_OUTPUT_NAME = 'ixbrlviewer.html'
 DEFAULT_VIEWER_PATH = os.path.join(os.path.dirname(__file__), "viewer", "dist", "ixbrlviewer.js")
+
+FEATURE_CONFIGS = [
+    FeatureConfig(
+        key='review',
+        label='Review Mode',
+        description='Enables highlighting of untagged numbers and dates.',
+        guiVisible=True,
+        guiDefault=False
+    )
+]
+
+GUI_FEATURE_CONFIGS = [c for c in FEATURE_CONFIGS if c.guiVisible]

--- a/iXBRLViewerPlugin/featureConfig.py
+++ b/iXBRLViewerPlugin/featureConfig.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, repr=False, eq=False)
+class FeatureConfig:
+    key: str
+    label: str
+    description: str
+    guiVisible: bool
+    guiDefault: bool

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -23,7 +23,7 @@ from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from lxml import etree
 
-from iXBRLViewerPlugin.constants import DEFAULT_VIEWER_PATH
+from .constants import DEFAULT_OUTPUT_NAME, DEFAULT_VIEWER_PATH, FEATURE_CONFIGS
 from .xhtmlserialize import XHTMLSerializer
 
 
@@ -37,10 +37,6 @@ LINK_QNAME_TO_LOCAL_DOCUMENTS_LINKBASE_TYPE = {
 }
 
 WIDER_NARROWER_ARCROLE = 'http://www.esma.europa.eu/xbrl/esef/arcrole/wider-narrower'
-
-VIEWER_FEATURES_AND_DESCRIPTIONS = {
-    "review": "Enables highlighting of untagged numbers and dates.",
-}
 
 class NamespaceMap:
     """
@@ -102,8 +98,9 @@ class IXBRLViewerBuilder:
     def enableFeature(self, featureName: str):
         if featureName in self.taxonomyData["features"]:
             return
-        assert featureName in VIEWER_FEATURES_AND_DESCRIPTIONS, \
-            f'Given feature name `{featureName}` does not match any defined features: {VIEWER_FEATURES_AND_DESCRIPTIONS.keys()}'
+        featureNames = [c.key for c in FEATURE_CONFIGS]
+        assert featureName in featureNames, \
+            f'Given feature name `{featureName}` does not match any defined features: {featureNames}'
         self.taxonomyData["features"].append(featureName)
 
     def outputFilename(self, filename):
@@ -420,7 +417,7 @@ class IXBRLViewerBuilder:
 
             if useStubViewer:
                 xmlDocument = self.getStubDocument()
-                iv.addFile(iXBRLViewerFile("ixbrlviewer.html", xmlDocument))
+                iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, xmlDocument))
             else:
                 xmlDocument = next(iter(xmlDocsByFilename.values()))
 
@@ -431,7 +428,7 @@ class IXBRLViewerBuilder:
             xmlDocument = self.getStubDocument()
             filename = self.outputFilename(os.path.basename(dts.modelDocument.filepath))
             docSetFiles = [ filename ]
-            iv.addFile(iXBRLViewerFile("ixbrlviewer.html", xmlDocument))
+            iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, xmlDocument))
             iv.addFile(iXBRLViewerFile(filename, dts.modelDocument.xmlDocument))
 
         else:

--- a/iXBRLViewerPlugin/ui.py
+++ b/iXBRLViewerPlugin/ui.py
@@ -8,102 +8,245 @@ except ImportError:
 
 import os
 
+from .constants import CONFIG_FEATURE_PREFIX, CONFIG_FILE_DIRECTORY, CONFIG_LAUNCH_ON_LOAD, \
+    CONFIG_OUTPUT_FILE, CONFIG_SCRIPT_URL, CONFIG_ZIP_OUTPUT, DEFAULT_LAUNCH_ON_LOAD, \
+    DEFAULT_VIEWER_PATH, GUI_FEATURE_CONFIGS
 
-class SaveViewerDialog(Toplevel):
+
+class BaseViewerDialog(Toplevel):
+    """
+    Base class for shared dialog configuration between settings and save dialogs
+    """
     def __init__(self, cntlr):
-
-        super(SaveViewerDialog, self).__init__(cntlr.parent)
-
+        super(BaseViewerDialog, self).__init__(cntlr.parent)
         self.cntlr = cntlr
         self.parent = cntlr.parent
-        self.accepted = False
 
-        self.title("Save iXBRL Viewer")
-
-        frame = Frame(self)
+        self._features = {}
+        for featureConfig in GUI_FEATURE_CONFIGS:
+            featureVar = BooleanVar()
+            featureVar.set(self.cntlr.config.setdefault(f'{CONFIG_FEATURE_PREFIX}{featureConfig.key}', featureConfig.guiDefault))
+            self._features[featureConfig.key] = featureVar
         self._scriptUrl = StringVar()
-        self._scriptUrl.set(self.cntlr.config.setdefault('iXBRLViewerScriptURL', os.path.join(os.path.dirname(__file__), 'viewer', 'dist', 'ixbrlviewer.js')))
-        self._filename = StringVar()
-        self._filename.set(self.cntlr.config.setdefault("iXBRLViewerOutputFile",""))
-        self._zipViewerOutput = BooleanVar()
-        self._zipViewerOutput.set(self.cntlr.config.setdefault("iXBRLViewerZipOutput", False))
+        self._scriptUrl.set(self.cntlr.config.setdefault(CONFIG_SCRIPT_URL, DEFAULT_VIEWER_PATH))
 
-        y = 1
+    def addButtons(self, frame: Frame, x: int, y: int) -> int:
+        """
+        Adds base buttons (OK, Cancel) to `frame` starting at column `x` on row `y`.
+        Can be extended to add buttons before or after base buttons.
+        :param frame: Frame to add buttons to
+        :param x: Grid column to start at
+        :param y: Grid row to add buttons on
+        :return: Column `x` that the last button was added on
+        """
+        x += 1
+        okButton = Button(frame, text=_("OK"), command=self.confirm)
+        okButton.grid(row=y, column=x, sticky=E, pady=3, padx=3)
+        x += 1
+        cancelButton = Button(frame, text=_("Cancel"), command=self.close)
+        cancelButton.grid(row=y, column=x, sticky=E, pady=3, padx=3)
+        return x
 
+    def addFields(self, frame: Frame, y: int) -> int:
+        """
+        Adds base fields to `frame` starting on row `y`.
+        Can be extended to add fields before or after base fields.
+        :param frame: Frame to add fields to
+        :param y: Grid row to add buttons on
+        :return: Row `y` that the last field was added on
+        """
+        y += 1
         scriptUrlLabel = Label(frame, text="Script URL")
-        scriptUrlEntry = Entry(frame, textvariable = self._scriptUrl, width=80)
-
+        scriptUrlEntry = Entry(frame, textvariable=self._scriptUrl, width=80)
         scriptUrlLabel.grid(row=y, column=0, sticky=W, pady=3, padx=3)
         scriptUrlEntry.grid(row=y, column=1, columnspan=2, sticky=EW, pady=3, padx=3)
 
         y += 1
+        featuresLabel = Label(frame, text="Generate with optional features:")
+        featuresLabel.grid(row=y, column=0, columnspan=2, pady=3, padx=3, sticky=W)
+        for featureConfig in GUI_FEATURE_CONFIGS:
+            y += 1
+            featureVar = self._features[featureConfig.key]
+            featureCheckbutton = Checkbutton(frame, text=featureConfig.label, variable=featureVar, onvalue=True, offvalue=False)
+            featureLabel = Label(frame, text=featureConfig.description)
+            featureCheckbutton.grid(row=y, column=0, pady=3, padx=3, sticky=W)
+            featureLabel.grid(row=y, column=1, columnspan=2, pady=3, padx=3, sticky=W)
+        return y
 
-        filenameLabel = Label(frame, text="iXBRL file")
-        filenameEntry = Entry(frame, textvariable = self._filename, width=80)
-        filenameBrowse = Button(frame, text=_("Browse..."), command=self.browseForFile)
+    def close(self):
+        """
+        Closes the dialog.
+        """
+        self.parent.focus_set()
+        self.destroy()
 
-        filenameLabel.grid(row=y, column=0, sticky=W, pady=3, padx=3)
-        filenameEntry.grid(row=y, column=1, sticky=EW, pady=3, padx=3)
-        filenameBrowse.grid(row=y, column=2, sticky=EW, pady=3, padx=3)
+    def confirm(self):
+        """
+        Closes the dialog after calling `onConfirm`.
+        """
+        self.onConfirm()
+        self.close()
+
+    def getTitle(self) -> str:
+        """
+        :return: Title of dialog window
+        """
+        pass
+
+    def onConfirm(self):
+        """
+        Actions to confirm when "OK" button or "Enter" key are pressed.
+        Window is closed immediately after.
+        """
+        pass
+
+    def render(self):
+        """
+        Performs the arrangement and rendering if dialog fields and buttons.
+        Process control is held here via `wait_window` until the dialog is closed.
+        """
+        self.title(self.getTitle())
+
+        frame = Frame(self)
+
+        y = 1
+        y = self.addFields(frame, y)
 
         y += 1
+        x = 0
+        self.addButtons(frame, x, y)
 
-        zipViewerOutputCheckbutton = Checkbutton(frame, text="Zip Viewer Output", variable=self._zipViewerOutput, onvalue=True, offvalue=False)
-        zipViewerOutputCheckbutton.grid(row=y, column=0, pady=3, padx=3)
-
-        y += 1
-
-        okButton = Button(frame, text=_("OK"), command=self.ok)
-        cancelButton = Button(frame, text=_("Cancel"), command=self.close)
-        okButton.grid(row=y, column=1, sticky=E, pady=3)
-        cancelButton.grid(row=y, column=2, columnspan=1, sticky=E, pady=3, padx=3)
-
-        frame.grid(row=0, column=0, sticky=(N,E,S,W))
+        frame.grid(row=0, column=0, padx=10, pady=10, sticky=(N,E,S,W))
         frame.columnconfigure(1, weight=1)
 
         window = self.winfo_toplevel()
         window.columnconfigure(0, weight=1)
-        #self.geometry("+{0}+{1}".format(dialogX+50,dialogY+100))
 
-        self.bind("<Return>", self.ok)
+        self.bind("<Return>", self.confirm)
         self.bind("<Escape>", self.close)
 
         self.protocol("WM_DELETE_WINDOW", self.close)
         self.grab_set()
         self.wait_window(self)
 
-   
-    def close(self, event=None):
-        self.parent.focus_set()
-        self.destroy()
-
-
-    def ok(self, event=None):
-        self.cntlr.config['iXBRLViewerOutputFile'] = self._filename.get()
-        self.cntlr.config['iXBRLViewerScriptURL'] = self._scriptUrl.get()
-        self.cntlr.config["iXBRLViewerFileDir"] = os.path.dirname(self._filename.get())
-        self.cntlr.saveConfig()
-        self.accepted = True
-        self.close()
-
-    def cancel(self, event=None):
-        self.close()
-
-    def browseForFile(self, event=None):
-        instanceFile = self.cntlr.uiFileDialog("save",
-                parent=self,
-                title=_("arelle - Save iXBRL Viewer Instance"),
-                initialdir=self.cntlr.config.setdefault("iXBRLViewerFileDir","."),
-                filetypes=[(_("iXBRL report .html"), "*.html")],
-                defaultextension=".html")
-        self._filename.set(instanceFile)
-        pass
+    def features(self):
+        # Return list of feature keys with corresponding BooleanVar is set to True
+        return [feature for feature, value in self._features.items() if value.get()]
 
     def scriptUrl(self):
         return self._scriptUrl.get()
+
+
+class SaveViewerDialog(BaseViewerDialog):
+    """
+    Dialog for saving a viewer instance.
+    Initializes with (but doesn't overwrite) default settings configured in the settings dialog.
+    """
+
+    def __init__(self, cntlr):
+        super(SaveViewerDialog, self).__init__(cntlr)
+        self.accepted = False
+        self._filename = StringVar()
+        self._filename.set(self.cntlr.config.setdefault(CONFIG_OUTPUT_FILE, ""))
+        self._zipViewerOutput = BooleanVar()
+        self._zipViewerOutput.set(self.cntlr.config.setdefault(CONFIG_ZIP_OUTPUT, False))
+
+    def addFields(self, frame: Frame, y: int) -> int:
+        """
+        Adds filename and zip output fields before other settings.
+        """
+        y += 1
+        filenameLabel = Label(frame, text="iXBRL file")
+        filenameEntry = Entry(frame, textvariable=self._filename, width=80)
+        filenameBrowse = Button(frame, text=_("Browse..."), command=self.browseForFile)
+        filenameLabel.grid(row=y, column=0, sticky=W, pady=3, padx=3)
+        filenameEntry.grid(row=y, column=1, sticky=EW, pady=3, padx=3)
+        filenameBrowse.grid(row=y, column=2, sticky=EW, pady=3, padx=3)
+        y += 1
+        zipViewerOutputCheckbutton = Checkbutton(frame, text="Zip Viewer Output", variable=self._zipViewerOutput, onvalue=True, offvalue=False)
+        zipViewerOutputCheckbutton.grid(row=y, column=0, pady=3, padx=3)
+        return super(SaveViewerDialog, self).addFields(frame, y)
+
+    def browseForFile(self):
+        instanceFile = self.cntlr.uiFileDialog(
+            "save",
+            parent=self,
+            title=_("arelle - Save iXBRL Viewer Instance"),
+            initialdir=self.cntlr.config.setdefault(CONFIG_FILE_DIRECTORY, "."),
+            filetypes=[(_("iXBRL report .html"), "*.html")],
+            defaultextension=".html")
+        self._filename.set(instanceFile)
+        pass
+
+    def getTitle(self) -> str:
+        return "Save iXBRL Viewer"
+
+    def onConfirm(self):
+        """
+        Saves output-specific config values before triggering instance to be saved.
+        """
+        self.cntlr.config[CONFIG_FILE_DIRECTORY] = os.path.dirname(self.filename())
+        self.cntlr.config[CONFIG_OUTPUT_FILE] = self.filename()
+        self.cntlr.config[CONFIG_ZIP_OUTPUT] = self.zipViewerOutput()
+        self.cntlr.saveConfig()
+        self.accepted = True
 
     def filename(self):
         return self._filename.get()
 
     def zipViewerOutput(self):
         return self._zipViewerOutput.get()
+
+
+class SettingsDialog(BaseViewerDialog):
+    """
+    Dialog for saving default viewer settings.
+    """
+
+    def __init__(self, cntlr):
+        super(SettingsDialog, self).__init__(cntlr)
+        self._launchOnLoad = BooleanVar()
+        self._launchOnLoad.set(self.cntlr.config.setdefault(CONFIG_LAUNCH_ON_LOAD, DEFAULT_LAUNCH_ON_LOAD))
+
+    def addButtons(self, frame: Frame, x: int, y: int) -> int:
+        """
+        Adds reset button before OK button
+        """
+        x += 1
+        resetButton = Button(frame, text=_("Reset Defaults"), command=self.reset)
+        resetButton.grid(row=y, column=x, sticky=E, pady=3, padx=30)
+        return super(SettingsDialog, self).addButtons(frame, x, y)
+
+    def addFields(self, frame: Frame, y: int) -> int:
+        """
+        Adds launch-on-load checkbox above other settings
+        """
+        y += 1
+        launchOnLoadCheckbutton = Checkbutton(frame, text="Launch on Load", variable=self._launchOnLoad, onvalue=True, offvalue=False)
+        launchOnLoadLabel = Label(frame, text="Launches an instance of the viewer in Stub Viewer Mode whenever a document is loaded.")
+        launchOnLoadCheckbutton.grid(row=y, column=0, pady=3, padx=3, sticky=W)
+        launchOnLoadLabel.grid(row=y, column=1, columnspan=3, pady=3, padx=3, sticky=W)
+        return super(SettingsDialog, self).addFields(frame, y)
+
+    def getTitle(self) -> str:
+        return "iXBRL Viewer Settings"
+
+    def onConfirm(self):
+        """
+        Saves configuration values for saving viewers as well as global viewer behavior settings
+        """
+        self.cntlr.config[CONFIG_LAUNCH_ON_LOAD] = self._launchOnLoad.get()
+        self.cntlr.config[CONFIG_SCRIPT_URL] = self._scriptUrl.get()
+        for key, var in self._features.items():
+            self.cntlr.config[f'{CONFIG_FEATURE_PREFIX}{key}'] = var.get()
+        self.cntlr.saveConfig()
+        self.close()
+
+    def reset(self):
+        """
+        Resets dialog variable values to default values
+        """
+        self._launchOnLoad.set(DEFAULT_LAUNCH_ON_LOAD)
+        self._scriptUrl.set(DEFAULT_VIEWER_PATH)
+        for featureConfig in GUI_FEATURE_CONFIGS:
+            self._features[featureConfig.key].set(featureConfig.guiDefault)

--- a/iXBRLViewerPlugin/ui.py
+++ b/iXBRLViewerPlugin/ui.py
@@ -73,19 +73,19 @@ class BaseViewerDialog(Toplevel):
             featureLabel.grid(row=y, column=1, columnspan=2, pady=3, padx=3, sticky=W)
         return y
 
-    def close(self):
+    def close(self, event=None):
         """
         Closes the dialog.
         """
         self.parent.focus_set()
         self.destroy()
 
-    def confirm(self):
+    def confirm(self, event=None):
         """
         Closes the dialog after calling `onConfirm`.
         """
         self.onConfirm()
-        self.close()
+        self.close(event)
 
     def getTitle(self) -> str:
         """
@@ -242,7 +242,7 @@ class SettingsDialog(BaseViewerDialog):
         self.cntlr.saveConfig()
         self.close()
 
-    def reset(self):
+    def reset(self, event=None):
         """
         Resets dialog variable values to default values
         """

--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -23,7 +23,7 @@ import glob
 import argparse
 import iXBRLViewerPlugin.iXBRLViewer
 from arelle.plugin import inlineXbrlDocumentSet
-from iXBRLViewerPlugin import generateViewer, getFeaturesFromOptions, VIEWER_FEATURES_AND_DESCRIPTIONS
+from iXBRLViewerPlugin import generateViewer, getFeaturesFromOptions, FEATURE_CONFIGS
 
 class CntlrCreateViewer(Cntlr.Cntlr):
 
@@ -71,9 +71,9 @@ parser.add_argument("--use-stub-viewer",
 parser.add_argument('files', metavar='FILES', nargs='+',
                     help='Files to process')
 featureGroup = parser.add_argument_group('Viewer Features')
-for featureName, featureDescription in VIEWER_FEATURES_AND_DESCRIPTIONS.items():
-    arg = f'--viewer-feature-{featureName}'
-    featureGroup.add_argument(arg, arg.lower(), action="store_true", default=False, help=featureDescription)
+for featureConfig in FEATURE_CONFIGS:
+    arg = f'--viewer-feature-{featureConfig.key}'
+    featureGroup.add_argument(arg, arg.lower(), action="store_true", default=False, help=featureConfig.description)
 
 args = parser.parse_args()
 


### PR DESCRIPTION
*Recommend reviewing by commit!*

#### Reason for change
Closes #520 

#### Description of change
- Implemented `FeatureConfig` which can be used to easily add additional features going forward
- Fixed "Load on launch" setting which hasn't been working since [this commit](https://github.com/Arelle/w-ixbrl-viewer). The setting was not being checked causing Arelle to *always* launch on load.
- Split save dialog into two separate dialogs:
  - Save dialog: for saving a viewer instance, initialized with default values from config but doesn't overwrite them
  - Settings dialog: for saving default settings that populate the save dialog and are used by launch-on-load
- Moved "launch-on-load" toggle from View menu to new Settings dialog
- Configured launch-on-load to generate viewer using configured settings (features and script URL)

### Updated Menu:
![Screenshot 2023-07-27 at 12 07 10 PM](https://github.com/Arelle/ixbrl-viewer/assets/105066394/5f289ed0-e584-42eb-a8ea-1273c3a63f85)

### Save Dialog:
![Screenshot 2023-08-01 at 11 44 01 AM](https://github.com/Arelle/ixbrl-viewer/assets/105066394/f53c907d-8fc8-4319-80ba-877e5a21ad81)

### Settings Dialog
![Screenshot 2023-08-01 at 11 43 14 AM](https://github.com/Arelle/ixbrl-viewer/assets/105066394/d112210d-0620-4db6-a3fe-851d45ff8106)

#### Steps to Test

- Generate viewers with various combinations of: 
  - Both pathways: Load-on-launch, `Save Viewer...`
  - Different settings: Review Mode on/off
  - Different viewer URLs
- Confirm settings saved in settings dialog interact as expected with settings that populate in save dialog, and vice versa
- Confirm viewer does *not* launch when loading a document if launch-on-load is disabled
- Confirm `Reset Defaults` button on settings dialog works as expected

**review**:
@Workiva/xt
@paulwarren-wk
