### PR TITLE
Hide file summary if no files present.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -528,12 +528,14 @@ export class Inspector {
         } = this.summary.getLocalDocuments();
 
         const summaryFilesContent = summaryDom.find(".files-summary");
+        let visibleItems = 0;
 
         function insertFileSummary(docs, classSelector) {
             if (docs.length === 0) {
                 summaryFilesContent.find(classSelector).hide();
             } else {
                 const ul = summaryFilesContent.find(classSelector + ' ul')
+                visibleItems += 1;
                 for (const doc of docs) {
                     ul.append($("<li></li>").text(doc));
                 }
@@ -548,6 +550,9 @@ export class Inspector {
         insertFileSummary(labelLinkbase, ".label-links");
         insertFileSummary(refLinkbase, ".ref-links");
         insertFileSummary(unrecognizedLinkbase, ".other-links");
+        if (visibleItems == 0) {
+            summaryFilesContent.hide();
+        }
     };
 
     createOutline() {


### PR DESCRIPTION
#### Reason for change

If the current viewer is used on reports prepared for an older viewer, the information to populate the file summary section is not present, leading to an empty section header:

![image](https://github.com/Arelle/ixbrl-viewer/assets/6639960/445321a4-548c-46dd-bdae-471d1cd8a89b)

#### Description of change

This removes the section entirely if it is empty.

#### Steps to Test

* Either: Build a viewer using a release older than 1.1.68, then copy ixbrlviewer.js built from this PR in place of the older one.  
* Or: build a viewer using this PR, and then manually delete the `localDocs` property from the JSON data.
* Check that there "File Summary" heading is completely absent, rather than empty

**review**:
@Arelle/arelle
@paulwarren-wk
