### PR TITLE
Show "Concealed fact" tag on transparent facts

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -46,6 +46,6 @@ export class IXNode {
     }
 
     htmlHidden() {
-        return this.wrapperNodes.is(':hidden') || this.wrapperNodes.filter((i,e) => isTransparent($(e).css('color'))).length > 0;
+        return this.wrapperNodes.is(':hidden') || this.wrapperNodes.is((i,e) => isTransparent($(e).css('color')));
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -1,5 +1,7 @@
 // See COPYRIGHT.md for copyright information
 
+import $ from 'jquery';
+import { isTransparent } from './util.js';
 
 /*
  * Object to hold information related to iXBRL nodes in the HTML document.
@@ -44,6 +46,6 @@ export class IXNode {
     }
 
     htmlHidden() {
-        return this.wrapperNodes.is(':hidden');
+        return this.wrapperNodes.is(':hidden') || this.wrapperNodes.filter((i,e) => isTransparent($(e).css('color'))).length > 0;
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -149,3 +149,14 @@ export function titleCase(text) {
                 .join('');
     }).join(' ');
 }
+
+/**
+ * Extract the alpha value from an rgba(r,g,b,a) string and returns true if
+ * transparent (a < 10%).  Returns false on rgb(r,g,b) strings.
+ * @param  {String}  rgba   color string to parse
+ * @return {Boolean} whether the value is transparent
+ */
+export function isTransparent(rgba) {
+    const val = parseFloat(rgba.split(",")[3]);
+    return !isNaN(val) && val < 0.1;
+}


### PR DESCRIPTION
#### Reason for change

Some preparers make the contents of iXBRL tags invisible, so that the visual appearance of the fact can be provided by different HTML elements.  The viewer currently detects where this is done using `display: none` and puts a "concealed fact" tag in the inspector.  We've recently discovered preparers doing the same thing, but using a transparent font color for the tag.

This is poor tagging practice, as it removes the connection between the tagged and displayed values, and interferes with the behaviour of viewers.

#### Description of change

This PR extends the check for concealed facts to include facts with a transparent font (which we define as an alpha value of less than 10%).

#### Steps to Test

Create a viewer for [this filing](https://filings.xbrl.org/213800O3Z6ZSDBAKG321/2022-12-31/ESEF/HR/2/granoliogroup-2022-12-31-en.zip)

Do a search for "Proft loss before tax".  Scroll through the results and you should see facts highlighted as "Concealed facts"

![image](https://github.com/Arelle/ixbrl-viewer/assets/45077928/a590ba53-5b3e-45a7-a9b9-0c805640195a)

Double click on one such result.

The fact inspector should also have a "Concealed fact" tag.

Now unselect this fact (e.g. click on the background).  Note that you can't click on the number to re-select the fact.  This is because the tagged fact is underneath another HTML element which is what is visible.


**review**:
@Arelle/arelle
@paulwarren-wk
