### PR TITLE
IXDS bug fixes

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -412,6 +412,7 @@ class IXBRLViewerBuilder:
             xmlDocsByFilename = {
                 os.path.basename(self.outputFilename(doc.filepath)): deepcopy(doc.xmlDocument)
                 for doc in sorted(dts.modelDocument.referencesDocument.keys(), key=lambda x: x.objectIndex)
+                if doc.type == Type.INLINEXBRL
             }
             docSetFiles = list(xmlDocsByFilename.keys())
 

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -445,9 +445,9 @@ class IXBRLViewerBuilder:
 
         localDocs = defaultdict(set)
         for path, doc in dts.urlDocs.items():
-            if isHttpUrl(path):
+            if isHttpUrl(path) or doc.type == Type.INLINEXBRLDOCUMENTSET:
                 continue
-            if doc.type in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET):
+            if doc.type == Type.INLINEXBRL:
                 localDocs[doc.basename].add('inline')
             elif doc.type == Type.SCHEMA:
                 localDocs[doc.basename].add('schema')

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -329,13 +329,21 @@ class TestIXBRLViewer(unittest.TestCase):
                 Mock(
                     xmlDocument=etree.ElementTree(root),
                     filepath='a.xml',
-                    objectIndex=0
+                    objectIndex=0,
+                    type=Type.INLINEXBRL,
                 ): [],
                 Mock(
                     xmlDocument=etree.ElementTree(root),
                     filepath='b.xml',
-                    objectIndex=1
-                ): []
+                    objectIndex=1,
+                    type=Type.INLINEXBRL,
+                ): [],
+                Mock(
+                    xmlDocument=etree.ElementTree(root),
+                    filepath='a.xsd',
+                    objectIndex=2,
+                    type=Type.SCHEMA,
+                ): [],
             },
             filepath=self.modelDocument.filepath,
             type=Type.INLINEXBRLDOCUMENTSET

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -377,8 +377,8 @@ class TestIXBRLViewer(unittest.TestCase):
             urlDocs=dict((
                 urlDocEntry('/filesystem/local-inline.htm', Type.INLINEXBRL),
                 urlDocEntry('https://example.com/remote-inline.htm', Type.INLINEXBRL),
-                urlDocEntry('/filesystem/local-docset', Type.INLINEXBRLDOCUMENTSET),
-                urlDocEntry('https://example.com/remote-docset', Type.INLINEXBRLDOCUMENTSET),
+                urlDocEntry('/filesystem/local-docset/_IXDS', Type.INLINEXBRLDOCUMENTSET),
+                urlDocEntry('https://example.com/remote-docset/_IXDS', Type.INLINEXBRLDOCUMENTSET),
                 urlDocEntry('/filesystem/local-schema.xsd', Type.SCHEMA),
                 urlDocEntry('https://example.com/remote-schema.xsd', Type.SCHEMA),
                 urlDocEntry('/filesystem/local-label-linkbase.xml', Type.LINKBASE, XbrlConst.qnLinkLabelLink),
@@ -525,7 +525,6 @@ class TestIXBRLViewer(unittest.TestCase):
         })
         self.assertEqual(jsdata["localDocs"], {
             'local-inline.htm': ['inline'],
-            'local-docset': ['inline'],
             'local-schema.xsd': ['schema'],
             'local-pres-linkbase.xml': ['presLinkbase'],
             'local-calc-linkbase.xml': ['calcLinkbase'],


### PR DESCRIPTION
#### Reason for change
IXDS viewer currently includes all referenced docs, including schemas. At runtime this generates tabs for all of the inline docs and referenced schemas (this can also cause an exception to be raised depending on how the viewer is hosted):
<img width="934" alt="Screenshot 2023-10-01 at 10 41 20 PM" src="https://github.com/Arelle/ixbrl-viewer/assets/46454775/4948c0de-ea86-4f02-a77c-540751a8eff0">

Additionally, the fake "_IXDS" doc is included as a local doc. This causes it to be included in the file summary:
<img width="210" alt="Screenshot 2023-10-01 at 10 41 35 PM" src="https://github.com/Arelle/ixbrl-viewer/assets/46454775/5ae25a57-a4c7-4402-a550-7055d4188b29">

#### Description of change
* Only include referenced inline docs in docset.
* Filter out fake IXDS doc from local docs.

#### Steps to Test
1. `mkdir viewer-out`
1. `python arelleCmdLine.py --plugins 'iXBRLViewerPlugin|inlineXbrlDocumentSet|transforms/SEC' --file '[{"ixds":[{"file":"filing_documents.zip"}]}]' --save-viewer viewer-out`
1. `python -m http.server --directory viewer-out`
1. open http://localhost:8000/avkr-20230630.htm and confirm tabs for `avkr-20230630.htm` and `avkr-20230630_d2.htm` both work.
1. `mkdir viewer-stub-out`
1. `python arelleCmdLine.py --plugins 'iXBRLViewerPlugin|inlineXbrlDocumentSet|transforms/SEC' --file '[{"ixds":[{"file":"filing_documents.zip"}]}]' --save-viewer viewer-stub-out --use-stub-viewer`
1. `python -m http.server --directory viewer-stub-out`
1. open http://localhost:8000/ixbrlviewer.html and confirm tabs for `avkr-20230630.htm` and `avkr-20230630_d2.htm` both work.
1. Open zip in GUI and select both `avkr-20230630.htm` and `avkr-20230630_d2.htm` with the three plugins enabled and confirm the same.

[filing_documents.zip](https://github.com/Arelle/ixbrl-viewer/files/12779281/filing_documents.zip)

**review**:
@Arelle/arelle
@paulwarren-wk
