### PR TITLE
Fix some incorrect type hints

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -15,10 +15,11 @@ from copy import deepcopy
 from typing import Optional, Union
 
 import pycountry
-from arelle import ModelXbrl, XbrlConst
+from arelle import XbrlConst
 from arelle.ModelDocument import Type
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelValue import QName, INVALIDixVALUE
+from arelle.ModelXbrl import ModelXbrl
 from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from lxml import etree
@@ -82,7 +83,7 @@ class IXBRLViewerBuilderError(Exception):
 
 class IXBRLViewerBuilder:
 
-    def __init__(self, reports: List[ModelXbrl], basenameSuffix: str = ''):
+    def __init__(self, reports: list[ModelXbrl], basenameSuffix: str = ''):
         self.nsmap = NamespaceMap()
         self.roleMap = NamespaceMap()
         self.reports = reports

--- a/tests/unit_tests/iXBRLViewerPlugin/mock_arelle.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/mock_arelle.py
@@ -29,6 +29,7 @@ def mock_arelle():
         sys.modules['arelle.ModelValue'] = Mock(
             QName=qname_effect
         )
+        sys.modules['arelle.ModelXbrl'] = Mock()
         sys.modules['arelle.PythonUtil'] = Mock()
         sys.modules['arelle.UrlUtil'] = Mock(
             isHttpUrl=lambda path: path.startswith('http')


### PR DESCRIPTION
#### Reason for change
Related to #581, some type hints were using wrong (or missing) imports causing a consuming application to raise type hint errors.

#### Description of change
* Use ModelXbrl class instead of module as type hint.
* Replace `List` type hint (with missing import from typing) with `list` type.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
