### PR TITLE
Fix reports fact reference

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/chart.js
+++ b/iXBRLViewerPlugin/viewer/src/js/chart.js
@@ -76,7 +76,7 @@ export class IXBRLChart extends Dialog {
             covered[dims[1]] = null;
         }
 
-        const facts = fact.report().deduplicate(fact.report().getAlignedFacts(fact, covered));
+        const facts = fact.report.deduplicate(fact.report.getAlignedFacts(fact, covered));
 
         /* Get the unique aspect values along each dimension.  This is to ensure
          * that we assign facts to datasets consistently (we have one dataset per value
@@ -123,7 +123,7 @@ export class IXBRLChart extends Dialog {
                 if (dims[1]) {
                     covered[dims[1]] = uv2[j].value();
                 }
-                const dp = fact.report().getAlignedFacts(fact, covered);
+                const dp = fact.report.getAlignedFacts(fact, covered);
                 if (dp.length > 0) {
                     dataSets[j].data[i] = dp[0].value()/(10**scale);
                 }


### PR DESCRIPTION
#### Reason for change
report changed from a function to a field of the Fact class in #568 

#### Description of change
Resolves `Uncaught TypeError: e.report is not a function` exception when opening one of the analyze diagrams.

#### Steps to Test
Click the analyze button on a fact:
<img width="385" alt="Screenshot 2023-11-07 at 4 09 07 PM" src="https://github.com/Arelle/ixbrl-viewer/assets/46454775/8a8b44dc-10a2-47ed-b2a2-99668dcaf1fb">


**review**:
@Arelle/arelle
@paulwarren-wk
