### PR TITLE
Update legacy/VUID fact ID usage for SHOW_FACT and SEC/ESEF hidden facts

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/docOrderIndex.js
+++ b/iXBRLViewerPlugin/viewer/src/js/docOrderIndex.js
@@ -5,21 +5,21 @@ export class DocOrderIndex {
         this.index = [];
     }
 
-    addItem(id, docIndex) {
-        this.index.push({id: id, docIndex: docIndex});
+    addItem(vuid, docIndex) {
+        this.index.push({vuid: vuid, docIndex: docIndex});
     }
 
-    getAdjacentItem(id, offset) {
-        const currentIndex = this.index.findIndex(n => n.id == id);
+    getAdjacentItem(vuid, offset) {
+        const currentIndex = this.index.findIndex(n => n.vuid === vuid);
         const l = this.index.length;
-        return this.index[(currentIndex + offset + l) % l].id;
+        return this.index[(currentIndex + offset + l) % l].vuid;
     }
 
     getFirstInDocument(docIndex) {
-        return this.index.filter(n => n.docIndex == docIndex)[0].id;
+        return this.index.filter(n => n.docIndex === docIndex)[0].vuid;
     }
 
     getLastInDocument(docIndex) {
-        return this.index.filter(n => n.docIndex == docIndex).at(-1).id;
+        return this.index.filter(n => n.docIndex === docIndex).at(-1).vuid;
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -131,7 +131,7 @@ export class Inspector {
     }
 
     initializeViewer() {
-        this._viewer.onSelect.add((id, eltSet, byClick) => this.selectItem(id, eltSet, byClick));
+        this._viewer.onSelect.add((vuid, eltSet, byClick) => this.selectItem(vuid, eltSet, byClick));
         this._viewer.onMouseEnter.add((id) => this.viewerMouseEnter(id));
         this._viewer.onMouseLeave.add(id => this.viewerMouseLeave(id));
         $('.ixbrl-next-tag').click(() => this._viewer.selectNextTag(this._currentItem));
@@ -889,7 +889,7 @@ export class Inspector {
 
         // dissolveSingle => title not shown if only one item in accordian
         const a = new Accordian({
-            onSelect: (id) => this.switchItem(id),
+            onSelect: (vuid) => this.switchItem(vuid),
             alwaysOpen: true,
             dissolveSingle: true,
         });
@@ -1042,9 +1042,9 @@ export class Inspector {
      * If itemIdList is omitted, the currently selected item list is reset to just
      * the primary item.
      */
-    selectItem(id, itemIdList, noScroll) {
+    selectItem(vuid, itemIdList, noScroll) {
         if (itemIdList === undefined) {
-            this._currentItemList = [ this._reportSet.getItemById(id) ];
+            this._currentItemList = [ this._reportSet.getItemById(vuid) ];
         }
         else {
             this._currentItemList = [];
@@ -1052,7 +1052,7 @@ export class Inspector {
                 this._currentItemList.push(this._reportSet.getItemById(itemId));
             }
         }
-        this.switchItem(id, noScroll);
+        this.switchItem(vuid, noScroll);
     }
 
     /*
@@ -1063,13 +1063,13 @@ export class Inspector {
      *
      * For footnotes, we currently only support a single footnote being selected.
      */
-    switchItem(id, noScroll) {
-        if (id !== null) {
-            this._currentItem = this._reportSet.getItemById(id);
+    switchItem(vuid, noScroll) {
+        if (vuid !== null) {
+            this._currentItem = this._reportSet.getItemById(vuid);
             if (!noScroll) {
-                this._viewer.showItemById(id);
+                this._viewer.showItemById(vuid);
             }
-            this._viewer.highlightItem(id);
+            this._viewer.highlightItem(vuid);
         }
         else {
             this._currentItem = null;

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1,7 +1,7 @@
 // See COPYRIGHT.md for copyright information
 
 import $ from 'jquery'
-import { formatNumber, wrapLabel, truncateLabel, runGenerator, viewerUniqueId } from "./util.js";
+import { formatNumber, wrapLabel, truncateLabel, runGenerator, SHOW_FACT, viewerUniqueId } from "./util.js";
 import { ReportSearch } from "./search.js";
 import { Calculation } from "./calculations.js";
 import { IXBRLChart } from './chart.js';
@@ -173,9 +173,14 @@ export class Inspector {
             // messages to itself when exporting files.
             return;
         }
-
-        if (data.task == 'SHOW_FACT') {
-            this.selectItem(data.factId);
+        const task = data["task"];
+        if (task === SHOW_FACT) {
+            let docSetId = Number(data["docSetId"]);
+            if (!docSetId) { // Handles NaN
+                docSetId = 0;
+            }
+            const vuid = viewerUniqueId(docSetId, data['factId']);
+            this.selectItem(vuid);
         }
         else {
             console.log("Not handling unsupported task message: " + jsonString);

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.js
@@ -79,12 +79,12 @@ export class ReportSet {
         ));
     }
 
-    getItemById(id) {
-        return this._items[id];
+    getItemById(vuid) {
+        return this._items[vuid];
     }
 
-    getIXNodeForItemId(id) {
-        return this._ixNodeMap[id] || {};
+    getIXNodeForItemId(vuid) {
+        return this._ixNodeMap[vuid] || {};
     }
 
     facts() {

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -3,6 +3,9 @@
 import moment from "moment";
 import Decimal from "decimal.js";
 
+
+export const SHOW_FACT = 'SHOW_FACT';
+
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date
  * and time if the time component is not midnight.  Adjust specifies that a

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -185,6 +185,18 @@ export function localId(viewerUniqueId) {
     return viewerUniqueId.replace(/^\d+-/,"");
 }
 
+/**
+ * Parses fact IDs from -sec-ix-hidden and -esef-ix-hidden style 
+ * attributes on a DOM node.  
+ * Any returned ID should be the ID of a fact in ix:hidden corresponding
+ * to the content contained in the DOM node.
+ * 
+ * @param  {Node}     domNode - DOM node to parse
+ * @return {String}   A fact ID, or null if the element does not have 
+ * a style attribute containing a custom CSS property in the required 
+ * format.
+ */
+
 export function getIXHiddenLinkStyle(domNode) {
     if (domNode.hasAttribute('style')) {
         const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -180,3 +180,14 @@ export function viewerUniqueId(sourceReportIndex, localId) {
 export function localId(viewerUniqueId) {
     return viewerUniqueId.replace(/^\d+-/,"");
 }
+
+export function getIXHiddenLinkStyle(domNode) {
+    if (domNode.hasAttribute('style')) {
+        const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
+        const m = domNode.getAttribute('style').match(re);
+        if (m) {
+            return m[1];
+        }
+    }
+    return null;
+}

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -169,12 +169,13 @@ export function isTransparent(rgba) {
  * in order to generate an ID that is guaranteed to be unique within the
  * viewer. This is already within an iXBRL Document Set, but not across
  * separate iXBRL documents or document sets.
- * @param  {Integer}  sourceReportIndex - index of the report document containing the fact
+ * @param  {Number}  sourceReportIndex - index of the report document containing the fact
+ * @param  {String}  localId - local ID of the fact
  * @return {String}   a viewer unique ID
  */
 
 export function viewerUniqueId(sourceReportIndex, localId) {
-    if (localId === null) {
+    if (localId === null || localId === undefined) {
         return null;
     }
     return sourceReportIndex.toString() + "-" + localId;

--- a/iXBRLViewerPlugin/viewer/src/js/util.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.test.js
@@ -1,6 +1,6 @@
 // See COPYRIGHT.md for copyright information
 
-import { xbrlDateToMoment, momentToHuman, formatNumber, wrapLabel, escapeRegex, truncateLabel } from "./util.js"
+import { xbrlDateToMoment, momentToHuman, formatNumber, wrapLabel, escapeRegex, truncateLabel, getIXHiddenLinkStyle } from "./util.js"
 import moment from 'moment';
 import "./moment-jest.js";
 
@@ -143,4 +143,35 @@ describe("Regex escape", () => {
     test("Regex escape", () => {
         expect(escapeRegex("a.b*{}")).toBe("a\\.b\\*\\{\\}")
     });
+});
+
+describe("Get IX Hidden Link Style", () => {
+    it.each([
+        ["-sec-ix-hidden:123", "123"],
+        ["-esef-ix-hidden:123", "123"],
+        ["-xxx-ix-hidden:123", null],
+        ["-sec-ix-hidden: 123", "123"],
+        ["-sec-ix-hidden:123 ", "123"],
+        ["-sec-ix-hidden:123;", "123"],
+        ["-sec-ix-hidden:123 abc", "123"],
+        ["xxx-sec-ix-hidden:123", null],
+        ["xxx;-sec-ix-hidden:123", "123"],
+        [" -sec-ix-hidden:123", "123"],
+        [";-sec-ix-hidden:123", "123"],
+        ["-sec-ix-Hidden:123", null],
+        ["-sec-ix-hidden:123;-sec-ix-hidden:abc", "123"],
+        ["", null],
+        [null, null],
+    ])("Style value %p returns %p", (style, result) => {
+        const domNode = document.createElement('div');
+        domNode.setAttribute("style", style);
+        const id = getIXHiddenLinkStyle(domNode);
+        expect(id).toEqual(result);
+    });
+
+    test("No style attribute returns null", () => {
+        const domNode = document.createElement('div');
+        const id = getIXHiddenLinkStyle(domNode);
+        expect(id).toEqual(null);
+    })
 });

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -378,10 +378,10 @@ export class Viewer {
             // Ignore iXBRL elements that are not in the default target document, as
             // the viewer builder does not handle these, and the builder does not
             // ensure that they have ID attributes.
-            const id = viewerUniqueId(reportIndex, n.getAttribute("id"));
+            const vuid = viewerUniqueId(reportIndex, n.getAttribute("id"));
             if (((isFact || isFootnote) && !n.hasAttribute("target"))
-                || (isContinuation && this.continuationOfMap[id] !== undefined)) {
-                var nodes;
+                || (isContinuation && this.continuationOfMap[vuid] !== undefined)) {
+                let nodes;
                 if (inHidden) {
                     nodes = $(n);
                 } else {
@@ -389,15 +389,15 @@ export class Viewer {
                 }
 
                 // For a continuation, store the IX ID(s) of the item(s), not the continuation
-                const headId = isContinuation ? this.continuationOfMap[id] : id;
+                const headId = isContinuation ? this.continuationOfMap[vuid] : vuid;
                 this._addIdToNode(nodes.first(), headId);
 
                 // We may have already created an IXNode for this ID from a -sec-ix-hidden
                 // element 
-                var ixn = this._ixNodeMap[id];
+                let ixn = this._ixNodeMap[vuid];
                 if (!ixn) {
-                    ixn = new IXNode(id, nodes, docIndex);
-                    this._ixNodeMap[id] = ixn;
+                    ixn = new IXNode(vuid, nodes, docIndex);
+                    this._ixNodeMap[vuid] = ixn;
                 }
                 if (inHidden) {
                     ixn.isHidden = true;
@@ -407,7 +407,7 @@ export class Viewer {
                     nodes.addClass("ixbrl-continuation");
                 }
                 else {
-                    this._docOrderItemIndex.addItem(id, docIndex);
+                    this._docOrderItemIndex.addItem(vuid, docIndex);
                 }
                 if (isNonFraction) {
                     nodes.addClass("ixbrl-element-nonfraction");
@@ -486,24 +486,24 @@ export class Viewer {
     // moving to the next/prev element
     //
     _selectAdjacentTag(offset, currentItem) {
-        var nextId;
+        var nextVuid;
         if (currentItem !== null) {
-            nextId = this._docOrderItemIndex.getAdjacentItem(currentItem.vuid, offset);
-            this.showDocumentForItemId(nextId);
+            nextVuid = this._docOrderItemIndex.getAdjacentItem(currentItem.vuid, offset);
+            this.showDocumentForItemId(nextVuid);
         }
         // If no fact selected go to the first or last in the current document
         else if (offset > 0) {
-            nextId = this._docOrderItemIndex.getFirstInDocument(this._currentDocumentIndex);
+            nextVuid = this._docOrderItemIndex.getFirstInDocument(this._currentDocumentIndex);
         } 
         else {
-            nextId = this._docOrderItemIndex.getLastInDocument(this._currentDocumentIndex);
+            nextVuid = this._docOrderItemIndex.getLastInDocument(this._currentDocumentIndex);
         }
         
-        const nextElement = this.elementsForItemId(nextId); 
+        const nextElement = this.elementsForItemId(nextVuid);
         this.showElement(nextElement);
         // If this is a table cell with multiple nested tags pass all tags so that
         // all are shown in the inspector. 
-        this.selectElement(nextId, this._ixIdsForElement(nextElement));
+        this.selectElement(nextVuid, this._ixIdsForElement(nextElement));
     }
 
     _bindHandlers() {
@@ -613,9 +613,9 @@ export class Viewer {
      * byClick indicates that the element was clicked directly, and in this
      * case we never scroll to make it more visible.
      */
-    selectElement(itemId, itemIdList, byClick) {
-        if (itemId !== null) {
-            this.onSelect.fire(itemId, itemIdList, byClick);
+    selectElement(vuid, itemIdList, byClick) {
+        if (vuid !== null) {
+            this.onSelect.fire(vuid, itemIdList, byClick);
         }
         else {
             this.onSelect.fire(null);
@@ -632,9 +632,9 @@ export class Viewer {
     // have nested elements, we select the innermost, as this gives the most
     // intuitive behaviour when clicking "next".
     selectElementByClick(e) {
-        var itemIDList = [];
+        let itemIDList = [];
         const viewer = this;
-        var sameContentAncestorId;
+        let sameContentAncestorVuid;
         // If the user clicked on a sub-element (and which is not also a proper
         // ixbrl-element) treat as if we clicked the first non-sub-element
         // ancestor in the DOM hierarchy - which would typically be
@@ -651,13 +651,13 @@ export class Viewer {
         // of the first one (sameContentAncestorId) that has exactly the same
         // content as "e"
         e.parents(".ixbrl-element").addBack().each(function () { 
-            const ids = viewer._ixIdsForElement($(this));
-            itemIDList = itemIDList.concat(ids); 
-            if ($(this).text() == e.text() && sameContentAncestorId === undefined) {
-                sameContentAncestorId = ids[0];
+            const vuids = viewer._ixIdsForElement($(this));
+            itemIDList = itemIDList.concat(vuids);
+            if ($(this).text() == e.text() && sameContentAncestorVuid === undefined) {
+                sameContentAncestorVuid = vuids[0];
             }
         });
-        this.selectElement(sameContentAncestorId, itemIDList, true);
+        this.selectElement(sameContentAncestorVuid, itemIDList, true);
     }
 
     _mouseEnter(e) {
@@ -694,15 +694,15 @@ export class Viewer {
         return this._ixNodeMap[vuid].wrapperNodes;
     }
 
-    elementsForItemIds(ids) {
-        return $(ids.map(id => this._ixNodeMap[id].wrapperNodes.get()).flat());
+    elementsForItemIds(vuids) {
+        return $(vuids.map(vuid => this.elementsForItemId(vuid).get()).flat());
     }
 
     /*
      * Add or remove a class to an item (fact or footnote) and any continuation elements
      */
-    changeItemClass(itemId, highlightClass, removeClass) {
-        const elements = this.elementsForItemIds([itemId].concat(this.itemContinuationMap[itemId]))
+    changeItemClass(vuid, highlightClass, removeClass) {
+        const elements = this.elementsForItemIds([vuid].concat(this.itemContinuationMap[vuid]))
         if (removeClass) {
             elements.removeClass(highlightClass);
         }
@@ -714,15 +714,15 @@ export class Viewer {
     /*
      * Change the currently highlighted item
      */
-    highlightItem(factId) {
+    highlightItem(vuid) {
         this.clearHighlighting();
-        this.changeItemClass(factId, "ixbrl-selected");
+        this.changeItemClass(vuid, "ixbrl-selected");
     }
 
-    showItemById(id) {
-        if (id !== null) {
-            let elts = this.elementsForItemId(id);
-            this.showDocumentForItemId(id);
+    showItemById(vuid) {
+        if (vuid !== null) {
+            let elts = this.elementsForItemId(vuid);
+            this.showDocumentForItemId(vuid);
             /* Hidden elements will return an empty node list */
             if (elts.length > 0) {
                 this.showElement(elts);
@@ -803,8 +803,8 @@ export class Viewer {
         $('#top-bar .document-title').text($('head title', this._iframes.eq(docIndex).contents()).text());
     }
 
-    showDocumentForItemId(itemId) {
-        this.selectDocument(this._ixNodeMap[itemId].docIndex);
+    showDocumentForItemId(vuid) {
+        this.selectDocument(this._ixNodeMap[vuid].docIndex);
     }
 
     currentDocument() {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -5,7 +5,7 @@ import { numberMatchSearch, fullDateMatch } from './number-matcher.js'
 import { TableExport } from './tableExport.js'
 import { escapeRegex, viewerUniqueId } from './util.js'
 import { IXNode } from './ixnode.js';
-import { setDefault, runGenerator } from './util.js';
+import { getIXHiddenLinkStyle, runGenerator } from './util.js';
 import { DocOrderIndex } from './docOrderIndex.js';
 import { MessageBox } from './messagebox.js';
 
@@ -435,21 +435,21 @@ export class Viewer {
             }
             else {
                 // Handle SEC/ESEF links-to-hidden
-                const id = this._getIXHiddenLinkStyle(n);
-                if (id !== null) {
-                    nodes = $(n);
-                    nodes.addClass("ixbrl-element").data('ivids', [id]);
-                    this._docOrderItemIndex.addItem(id, docIndex);
+                const vuid = viewerUniqueId(reportIndex, getIXHiddenLinkStyle(n));
+                if (vuid !== null) {
+                    let nodes = $(n);
+                    nodes.addClass("ixbrl-element").data('ivids', [vuid]);
+                    this._docOrderItemIndex.addItem(vuid, docIndex);
                     /* We may have already seen the corresponding ix element in the hidden
                      * section */
-                    const ixn = this._ixNodeMap[id];
+                    const ixn = this._ixNodeMap[vuid];
                     if (ixn) {
                         /* ... if so, update the node and docIndex so we can navigate to it */
                         ixn.wrapperNodes = nodes;
                         ixn.docIndex = docIndex;
                     }
                     else {
-                        this._ixNodeMap[id] = new IXNode(id, nodes, docIndex);
+                        this._ixNodeMap[vuid] = new IXNode(vuid, nodes, docIndex);
                     }
                 }
                 if (name == 'A') {
@@ -458,17 +458,6 @@ export class Viewer {
             }
         }
         this._preProcessChildNodes(n, reportIndex, docIndex, inHidden);
-    }
-
-    _getIXHiddenLinkStyle(domNode) {
-        if (domNode.hasAttribute('style')) {
-            const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
-            const m = domNode.getAttribute('style').match(re);
-            if (m) {
-                return m[1];
-            }
-        }
-        return null;
     }
 
     _preProcessChildNodes(domNode, reportIndex, docIndex, inHidden) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -687,8 +687,11 @@ export class Viewer {
     // Return a jQuery node list for wrapper elements corresponding to 
     // the factId.  May contain more than one node if the IX node contains
     // absolutely positioned elements.
-    elementsForItemId(factId) {
-        return this._ixNodeMap[factId].wrapperNodes; 
+    elementsForItemId(vuid) {
+        if (!(vuid in this._ixNodeMap)){
+            throw new Error(`Attempting to retrieve IXNode with missing key: ${vuid}`);
+        }
+        return this._ixNodeMap[vuid].wrapperNodes;
     }
 
     elementsForItemIds(ids) {


### PR DESCRIPTION
#### Reason for change
- The `SHOW_FACT` event was passing legacy fact IDs to `selectItem`
- Handling of SEC/ESEF links-to-hidden IDs was not using VUIDs

#### Description of change
Fix above cases where VUIDs were not being used, and do widespread renaming of `id` => `vuid` for clarity of where VUIDs are expected.

#### Steps to Test
CI

**review**:
@Arelle/arelle
@paulwarren-wk
