### PR TITLE
Add `iXBRLViewerPlugin` plugin alias

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -307,6 +307,9 @@ def load_plugin_url():
 
 __pluginInfo__ = {
     'name': 'ixbrl-viewer',
+    'aliases': [
+        'iXBRLViewerPlugin',
+    ],
     'version': '0.1',
     'description': "iXBRL Viewer creator",
     'license': 'License :: OSI Approved :: Apache License, Version 2.0 (Apache-2.0)',


### PR DESCRIPTION
#### Reason for change
Uses the aliases field introduced in Arelle/Arelle/pull/958 to support calling the plugin by both the name (`ixbrl-viewer`) and the prior plugin path (`iXBRLViewerPlugin`) when pip installed.

#### Description of change
Add `iXBRLViewerPlugin` plugin alias

#### Steps to Test
local pip install and call the plugin using both the name (`ixbrl-viewer`) and alias (`iXBRLViewerPlugin`).
* `python arelleCmdLine.py --plugins iXBRLViewerPlugin --save-viewer ixbrl-viewer.htm --file https://filings.xbrl.org/529900FSU45YYVLKB451/2023-09-30/ESEF/DK/0/529900FSU45YYVLKB451-2023-09-30-EN.zip`
* `python arelleCmdLine.py --plugins ixbrl-viewer --save-viewer ixbrl-viewer.htm --file https://filings.xbrl.org/529900FSU45YYVLKB451/2023-09-30/ESEF/DK/0/529900FSU45YYVLKB451-2023-09-30-EN.zip`

**review**:
@Arelle/arelle
@paulwarren-wk
