### PR TITLE
Display complex units correctly

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/aspect.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.js
@@ -56,7 +56,7 @@ export class Aspect {
             return this._report.getLabel(this._value, rolePrefix) || this._value;
         }
         else if (this._aspect === 'u') {
-            return this._report.reportSet.getUnit(this._value).measureLabel();
+            return this._report.reportSet.getUnit(this._value).label();
         }
         else if (this._aspect === 'p') {
             const p = new Period(this._value);

--- a/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/aspect.test.js
@@ -3,11 +3,12 @@
 import { Aspect, AspectSet } from "./aspect.js";
 import { ReportSet } from "./reportset.js";
 import { TestInspector } from "./test-utils.js";
+import { NAMESPACE_ISO4217 } from "./util";
 
 const testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217"
+        "iso4217": NAMESPACE_ISO4217
     },
     "facts" : {},
     "concepts": {

--- a/iXBRLViewerPlugin/viewer/src/js/chart.js
+++ b/iXBRLViewerPlugin/viewer/src/js/chart.js
@@ -97,7 +97,7 @@ export class IXBRLChart extends Dialog {
         const uv2 = set2av.uniqueValues();
 
         const scale = this._chooseMultiplier(facts);
-        const yLabel = fact.measureLabel() + " " + this._multiplierDescription(scale);
+        const yLabel = fact.unitLabel() + " " + this._multiplierDescription(scale);
         const labels = [];
         
         const dataSets = [];

--- a/iXBRLViewerPlugin/viewer/src/js/chart.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/chart.test.js
@@ -1,14 +1,14 @@
 // See COPYRIGHT.md for copyright information
 
-import { Fact } from "./fact.js";
 import { IXBRLChart } from "./chart.js";
 import { ReportSet } from "./reportset.js";
 import { TestInspector } from "./test-utils.js";
+import { NAMESPACE_ISO4217 } from "./util";
 
 var testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
     },
     "concepts": {

--- a/iXBRLViewerPlugin/viewer/src/js/concept.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.test.js
@@ -1,12 +1,12 @@
 // See COPYRIGHT.md for copyright information
 
-import { XBRLReport } from "./report.js";
 import { ReportSet } from "./reportset.js";
+import { NAMESPACE_ISO4217 } from "./util";
 
 const testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
     },
     "concepts": {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -109,14 +109,6 @@ export class Fact {
     }
 
     /**
-     * Returns the qname of the first numerator in the fact's unit
-     * @return {String} QName string of a measure
-     */
-    measure() {
-        return this.unit()?.measure();
-    }
-
-    /**
      * Returns details about this fact's unit
      * @return {Unit} Unit instance
      */

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -77,7 +77,7 @@ export class Fact {
             else {
                 formattedNumber = formatNumber(v, d);
             }
-            if (this.isMonetaryValue() && this.unit().isSimple()) {
+            if (this.isMonetaryValue()) {
                 v = this.unitLabel() + " " + formattedNumber;
             }
             else {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -78,10 +78,10 @@ export class Fact {
                 formattedNumber = formatNumber(v, d);
             }
             if (this.isMonetaryValue()) {
-                v = this.measureLabel() + " " + formattedNumber;
+                v = this.unitLabel() + " " + formattedNumber;
             }
             else {
-                v = formattedNumber + " " + this.measureLabel();
+                v = formattedNumber + " " + this.unitLabel();
             }
         }
         else if (this.isNil()) {
@@ -117,14 +117,6 @@ export class Fact {
     }
 
     /**
-     * Returns a readable label representing the first numerator in the fact's unit
-     * @return {String} Label representing measure
-     */
-    measureLabel() {
-        return this.unit()?.measureLabel() ?? i18next.t("factDetails.noUnit");
-    }
-
-    /**
      * Returns details about this fact's unit
      * @return {Unit} Unit instance
      */
@@ -137,6 +129,14 @@ export class Fact {
             this._unit = this.report.reportSet.getUnit(unitKey);
         }
         return this._unit;
+    }
+
+    /**
+     * Returns a readable label representing the fact's unit
+     * @return {String} Label representing unit
+     */
+    unitLabel() {
+        return this.unit()?.label() ?? i18next.t("factDetails.noUnit");
     }
 
     getConceptPrefix() {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -77,7 +77,7 @@ export class Fact {
             else {
                 formattedNumber = formatNumber(v, d);
             }
-            if (this.isMonetaryValue()) {
+            if (this.isMonetaryValue() && this.unit().isSimple()) {
                 v = this.unitLabel() + " " + formattedNumber;
             }
             else {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -264,17 +264,12 @@ export class Fact {
     }
 
     getScaleLabel(value, isAccuracy=false) {
-        let measure = this.measure() ?? '';
-        if (measure) {
-            measure = this.report.qname(measure).localname;
-        }
         return this.report.getScaleLabel(
                 // We use the same table of labels for scale and accuracy,
                 // but decimals means "accurate to 10^-N" whereas scale means 10^N,
                 // so invert N for accuracy.
                 isAccuracy ? -value : value,
-                this.isMonetaryValue(),
-                measure
+                this.unit()
         );
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -537,7 +537,7 @@ describe("Readable value", () => {
     test("Other numeric", () => {
 
         expect(testFact({ "v": "10", d: -2, a: { u: "xbrli:foo" } }).readableValue())
-            .toBe("10 Foo");
+            .toBe("10 foo");
 
     });
 

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -3,11 +3,12 @@
 import { Fact } from "./fact.js";
 import { ReportSet } from "./reportset.js";
 import { TestInspector } from "./test-utils.js";
+import { NAMESPACE_ISO4217 } from "./util";
 
 var testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
     },
     "concepts": {

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -129,7 +129,7 @@ describe("Simple fact properties", () => {
         expect(f.isNumeric()).toBeTruthy();
         expect(f.decimals()).toEqual(-3);
         expect(f.isMonetaryValue()).toBeFalsy();
-        expect(f.readableValue()).toEqual("1,000 eg:USD");
+        expect(f.readableValue()).toEqual("1,000 USD");
         expect(f.unit().value()).toEqual("eg:USD");
         expect(f.measure()).toEqual("eg:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
@@ -150,7 +150,7 @@ describe("Simple fact properties", () => {
         expect(f.decimals()).toBeUndefined();
         expect(f.isNumeric()).toBeTruthy();
         expect(f.isMonetaryValue()).toBeFalsy();
-        expect(f.readableValue()).toEqual("1,000,000.0125 eg:USD");
+        expect(f.readableValue()).toEqual("1,000,000.0125 USD");
         expect(f.unit().value()).toEqual("eg:USD");
         expect(f.measure()).toEqual("eg:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
@@ -540,7 +540,7 @@ describe("Readable value", () => {
     test("Other numeric", () => {
 
         expect(testFact({ "v": "10", d: -2, a: { u: "xbrli:foo" } }).readableValue())
-            .toBe("10 xbrli:foo");
+            .toBe("10 Foo");
 
     });
 
@@ -637,7 +637,7 @@ describe("Unit aspect handling", () => {
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.unit()).toBeUndefined();
         expect(f.measure()).toBeUndefined();
-        expect(f.measureLabel()).toBe("<NOUNIT>");
+        expect(f.unitLabel()).toBe("<NOUNIT>");
     });
 
     test("Non-numeric, no unit", () => {    

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -109,7 +109,6 @@ describe("Simple fact properties", () => {
         expect(f.isMonetaryValue()).toBeTruthy();
         expect(f.readableValue()).toEqual("US $ 1,000");
         expect(f.unit().value()).toEqual("iso4217:USD");
-        expect(f.measure()).toEqual("iso4217:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
@@ -131,7 +130,6 @@ describe("Simple fact properties", () => {
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("1,000 USD");
         expect(f.unit().value()).toEqual("eg:USD");
-        expect(f.measure()).toEqual("eg:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
@@ -152,7 +150,6 @@ describe("Simple fact properties", () => {
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.readableValue()).toEqual("1,000,000.0125 USD");
         expect(f.unit().value()).toEqual("eg:USD");
-        expect(f.measure()).toEqual("eg:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");
@@ -636,7 +633,6 @@ describe("Unit aspect handling", () => {
         expect(f.isNumeric()).toBeTruthy();
         expect(f.isMonetaryValue()).toBeFalsy();
         expect(f.unit()).toBeUndefined();
-        expect(f.measure()).toBeUndefined();
         expect(f.unitLabel()).toBe("<NOUNIT>");
     });
 
@@ -648,7 +644,6 @@ describe("Unit aspect handling", () => {
         });
         expect(f.isNumeric()).toBeFalsy();
         expect(f.unit()).toBeUndefined();
-        expect(f.measure()).toBeUndefined();
     });
 });
 
@@ -708,7 +703,6 @@ describe("Fact errors", () => {
         expect(f.isMonetaryValue()).toBeTruthy();
         expect(f.readableValue()).toEqual("Invalid value");
         expect(f.unit().value()).toEqual("iso4217:USD");
-        expect(f.measure()).toEqual("iso4217:USD");
         expect(f.conceptQName().prefix).toEqual("eg");
         expect(f.conceptQName().localname).toEqual("Concept1");
         expect(f.conceptQName().namespace).toEqual("http://www.example.com");

--- a/iXBRLViewerPlugin/viewer/src/js/factset.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/factset.test.js
@@ -1,9 +1,7 @@
 // See COPYRIGHT.md for copyright information
 
-import { Fact } from "./fact.js";
 import { FactSet } from "./factset.js";
-import { viewerUniqueId } from "./util.js";
-import { XBRLReport } from "./report.js";
+import { NAMESPACE_ISO4217, viewerUniqueId } from "./util.js";
 import { ReportSet } from "./reportset.js";
 
 var i = 0;
@@ -11,7 +9,7 @@ var i = 0;
 var testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
     },
     "concepts": {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -1,15 +1,14 @@
 // See COPYRIGHT.md for copyright information
 
-import { Fact } from "./fact.js";
 import { ReportSet } from "./reportset.js";
 import { TestInspector } from "./test-utils.js";
-import { SHOW_FACT, viewerUniqueId } from "./util.js";
+import { NAMESPACE_ISO4217, SHOW_FACT, viewerUniqueId } from "./util.js";
 
 
 const testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
     },
     "concepts": {

--- a/iXBRLViewerPlugin/viewer/src/js/outline.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/outline.test.js
@@ -2,14 +2,14 @@
 
 import $ from 'jquery'
 import { ReportSet } from "./reportset.js";
-import { ReportSetOutline, DocumentOutline } from "./outline.js";
+import { DocumentOutline } from "./outline.js";
 import { IXNode } from "./ixnode.js";
-import { viewerUniqueId } from "./util.js";
+import { NAMESPACE_ISO4217, viewerUniqueId } from "./util.js";
 
 const testReportData = {
     prefixes: {
         eg: "http://www.example.com",
-        iso4217: "http://www.xbrl.org/2003/iso4217",
+        iso4217: NAMESPACE_ISO4217,
         e: "http://example.com/entity",
     },
     roles: {

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -179,10 +179,14 @@ export class XBRLReport {
         return this.reportSet.qname(v);
     }
 
-    getScaleLabel(scale, isMonetaryValue, currency=null) {
+    getScaleLabel(scale, unit) {
         let label = i18next.t(`scale.${scale}`, {defaultValue:"noName"});
-        if (isMonetaryValue && scale === -2) {
-            label = i18next.t(`currencies:cents${currency}`, {defaultValue: label});
+        if (unit && unit.isMonetary() && scale === -2) {
+            let measure = unit.value() ?? '';
+            if (measure) {
+                measure = this.qname(measure).localname;
+            }
+            label = i18next.t(`currencies:cents${measure}`, {defaultValue: label});
         }
         if (label === "noName") {
             return null;

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -2,6 +2,7 @@
 
 import { ReportSet } from "./reportset.js";
 import { ViewerOptions } from "./viewerOptions.js";
+import { NAMESPACE_ISO4217 } from "./util";
 
 var testReportData = {
     "languages": {
@@ -10,7 +11,7 @@ var testReportData = {
     },
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217"
+        "iso4217": NAMESPACE_ISO4217
     },
     "roles": {
         "role1": "https://www.example.com/role1",

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.test.js
@@ -2,7 +2,7 @@
 
 import { ReportSet } from "./reportset.js";
 import { ViewerOptions } from "./viewerOptions.js";
-import { viewerUniqueId } from "./util.js";
+import { NAMESPACE_ISO4217, viewerUniqueId } from "./util.js";
 import { createNumericFact } from "./test-utils.js";
 
 function anchoringRelationShips(include) {
@@ -28,7 +28,7 @@ function multiReportTestData(withAnchoring) {
         },
         "prefixes": {
             "eg": "http://www.example.com",
-            "iso4217": "http://www.xbrl.org/2003/iso4217"
+            "iso4217": NAMESPACE_ISO4217
         },
         "roles": {
             "role1": "https://www.example.com/role1",
@@ -131,7 +131,7 @@ function singleReportTestData() {
         },
         "prefixes": {
             "eg": "http://www.example.com",
-            "iso4217": "http://www.xbrl.org/2003/iso4217"
+            "iso4217": NAMESPACE_ISO4217
         },
         "roles": {
             "role1": "https://www.example.com/role1",

--- a/iXBRLViewerPlugin/viewer/src/js/unit.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.js
@@ -25,9 +25,8 @@ export class Unit {
                 return part.includes('*') ? `(${part})` : part;
             })
             .join('/');
-        this._measure = this._numerators[0];
     }
-    
+
     /**
      * Returns whether any of the numerators are an iso4217 monetary measure.
      * @return {Boolean}
@@ -42,14 +41,6 @@ export class Unit {
      */
     label() {
         return this._label;
-    }
-
-    /**
-     * Returns the qname of the first numerator in the unit
-     * @return {String} QName string of a measure
-     */
-    measure() {
-        return this._measure;
     }
 
     /**

--- a/iXBRLViewerPlugin/viewer/src/js/unit.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.js
@@ -4,44 +4,36 @@ import { measureLabel, NAMESPACE_ISO4217 } from "./util";
 
 export class Unit {
     
-    constructor(report, unitKey) {
-        this._report = report;
+    constructor(reportSet, unitKey) {
+        this._reportSet = reportSet;
         this._value = unitKey;
         const split = unitKey
                 .split(/[()]/ig).join('') // TODO: replace with .replaceAll(/[()]/ig,'') when no longer supporting node 14
                 .split('/');
         this._numerators = split[0].split('*');
         this._denominators = split.length > 1 ? split[1].split('*') : [];
-        this._isSimple = this._numerators.length === 1 && this._denominators.length === 0;
-        this._isMonetary = Boolean(this._numerators.find(n => this._report.qname(n).namespace === NAMESPACE_ISO4217));
+        this._isMonetary =
+                this._denominators.length === 0 &&
+                this._numerators.length === 1 &&
+                this._reportSet.qname(this._numerators[0]).namespace === NAMESPACE_ISO4217;
         this._label = split
             .map(measure => {
                 const part = measure
                     .split('*')
-                    .map(x => measureLabel(report, x))
+                    .map(x => measureLabel(this._reportSet, x))
                     .join('*');
                 return part.includes('*') ? `(${part})` : part;
             })
             .join('/');
         this._measure = this._numerators[0];
     }
-
-
+    
     /**
      * Returns whether any of the numerators are an iso4217 monetary measure.
      * @return {Boolean}
      */
     isMonetary() {
         return this._isMonetary;
-    }
-
-
-    /**
-     * Returns whether the unit is a simple measure (single numerator, no denominators).
-     * @return {Boolean}
-     */
-    isSimple() {
-        return this._isSimple;
     }
 
     /**

--- a/iXBRLViewerPlugin/viewer/src/js/unit.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.js
@@ -12,6 +12,7 @@ export class Unit {
                 .split('/');
         this._numerators = split[0].split('*');
         this._denominators = split.length > 1 ? split[1].split('*') : [];
+        this._isSimple = this._numerators.length === 1 && this._denominators.length === 0;
         this._isMonetary = Boolean(this._numerators.find(n => this._report.qname(n).namespace === NAMESPACE_ISO4217));
         this._label = split
             .map(measure => {
@@ -32,6 +33,15 @@ export class Unit {
      */
     isMonetary() {
         return this._isMonetary;
+    }
+
+
+    /**
+     * Returns whether the unit is a simple measure (single numerator, no denominators).
+     * @return {Boolean}
+     */
+    isSimple() {
+        return this._isSimple;
     }
 
     /**

--- a/iXBRLViewerPlugin/viewer/src/js/unit.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.js
@@ -1,7 +1,6 @@
 // See COPYRIGHT.md for copyright information
 
-import i18next from "i18next";
-import {titleCase} from "./util";
+import { measureLabel, NAMESPACE_ISO4217 } from "./util";
 
 export class Unit {
     
@@ -13,13 +12,16 @@ export class Unit {
                 .split('/');
         this._numerators = split[0].split('*');
         this._denominators = split.length > 1 ? split[1].split('*') : [];
-        this._isMonetary = Boolean(this._numerators.find(n => this._report.qname(n).namespace === "http://www.xbrl.org/2003/iso4217"));
-        this._label = split.map(x => {
-                const part = x.split('*').map(y => {
-                    return titleCase(y.split(':')[1]);
-                }).join('*');
+        this._isMonetary = Boolean(this._numerators.find(n => this._report.qname(n).namespace === NAMESPACE_ISO4217));
+        this._label = split
+            .map(measure => {
+                const part = measure
+                    .split('*')
+                    .map(x => measureLabel(report, x))
+                    .join('*');
                 return part.includes('*') ? `(${part})` : part;
-            }).join('/');
+            })
+            .join('/');
         this._measure = this._numerators[0];
     }
 
@@ -46,19 +48,6 @@ export class Unit {
      */
     measure() {
         return this._measure;
-    }
-
-    /**
-     * Returns a readable label representing the first numerator in the unit
-     * @return {String} Label representing measure
-     */
-    measureLabel() {
-        const measure = this.measure();
-        const qname = this._report.qname(measure);
-        if (qname.namespace === "http://www.xbrl.org/2003/iso4217") {
-            return i18next.t(`currencies:unitFormat${qname.localname}`, {defaultValue: qname.localname});
-        }
-        return measure;
     }
 
     /**

--- a/iXBRLViewerPlugin/viewer/src/js/unit.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.test.js
@@ -35,24 +35,24 @@ describe("Unit label", () => {
 
     test("Unit label for complex unit", () => {
         var unit = new Unit(testReport(), 'iso4217:USD/eg:share');
-        expect(unit.label()).toEqual('US $/Share');
+        expect(unit.label()).toEqual('US $/share');
     });
 
     test("Unit label for complex unit with numerator parentheses", () => {
         var unit = new Unit(testReport(), '(iso4217:USD*eg:share)/eg:shareholder');
-        expect(unit.label()).toEqual('(US $*Share)/Shareholder');
+        expect(unit.label()).toEqual('(US $*share)/shareholder');
     });
 
     test("Unit label for complex unit with denominator parentheses", () => {
         var unit = new Unit(testReport(), 'iso4217:USD/(eg:share*eg:shareholder)');
-        expect(unit.label()).toEqual('US $/(Share*Shareholder)');
+        expect(unit.label()).toEqual('US $/(share*shareholder)');
     });
 });
 
 describe("Unit label", () => {
     test("Unit label - known currency", () => {
         var unit = new Unit(testReport(), 'eg:share');
-        expect(unit.label()).toEqual('Share');
+        expect(unit.label()).toEqual('share');
     });
 
     test("Unit label - known currency", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/unit.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.test.js
@@ -3,11 +3,12 @@
 import { Unit } from "./unit.js";
 import { ReportSet } from "./reportset.js";
 import { TestInspector } from "./test-utils.js";
+import { NAMESPACE_ISO4217 } from "./util";
 
 var testReportData = {
     "prefixes": {
         "eg": "http://www.example.com",
-        "iso4217": "http://www.xbrl.org/2003/iso4217",
+        "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
     },
     "facts": {}

--- a/iXBRLViewerPlugin/viewer/src/js/unit.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.test.js
@@ -49,18 +49,6 @@ describe("Unit label", () => {
     });
 });
 
-describe("Unit measure", () => {
-    test("Unit measure is simple unit", () => {
-        var unit = new Unit(testReport(), 'iso4217:USD');
-        expect(unit.measure()).toEqual('iso4217:USD');
-    });
-
-    test("Unit measure is first numerator of complex unit", () => {
-        var unit = new Unit(testReport(), '(iso4217:USD*eg:share)/eg:shareholder');
-        expect(unit.measure()).toEqual('iso4217:USD');
-    });
-});
-
 describe("Unit label", () => {
     test("Unit label - known currency", () => {
         var unit = new Unit(testReport(), 'eg:share');
@@ -94,5 +82,9 @@ describe("Unit value", () => {
     test("Unit value is key", () => {
         var unit = new Unit(testReport(), '(iso4217:USD*eg:share)/eg:shareholder');
         expect(unit.value()).toEqual('(iso4217:USD*eg:share)/eg:shareholder');
+    });
+    test("Unit value is simple unit", () => {
+        var unit = new Unit(testReport(), 'iso4217:USD');
+        expect(unit.value()).toEqual('iso4217:USD');
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/unit.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.test.js
@@ -30,22 +30,22 @@ beforeAll(() => {
 describe("Unit label", () => {
     test("Unit label for simple unit", () => {
         var unit = new Unit(testReport(), 'iso4217:USD');
-        expect(unit.label()).toEqual('USD');
+        expect(unit.label()).toEqual('US $');
     });
 
     test("Unit label for complex unit", () => {
         var unit = new Unit(testReport(), 'iso4217:USD/eg:share');
-        expect(unit.label()).toEqual('USD/Share');
+        expect(unit.label()).toEqual('US $/Share');
     });
 
     test("Unit label for complex unit with numerator parentheses", () => {
         var unit = new Unit(testReport(), '(iso4217:USD*eg:share)/eg:shareholder');
-        expect(unit.label()).toEqual('(USD*Share)/Shareholder');
+        expect(unit.label()).toEqual('(US $*Share)/Shareholder');
     });
 
     test("Unit label for complex unit with denominator parentheses", () => {
         var unit = new Unit(testReport(), 'iso4217:USD/(eg:share*eg:shareholder)');
-        expect(unit.label()).toEqual('USD/(Share*Shareholder)');
+        expect(unit.label()).toEqual('US $/(Share*Shareholder)');
     });
 });
 
@@ -61,20 +61,20 @@ describe("Unit measure", () => {
     });
 });
 
-describe("Unit measure label", () => {
-    test("Unit measure label - known currency", () => {
+describe("Unit label", () => {
+    test("Unit label - known currency", () => {
         var unit = new Unit(testReport(), 'eg:share');
-        expect(unit.measureLabel()).toEqual('eg:share');
+        expect(unit.label()).toEqual('Share');
     });
 
-    test("Unit measure label - known currency", () => {
+    test("Unit label - known currency", () => {
         var unit = new Unit(testReport(), 'iso4217:USD');
-        expect(unit.measureLabel()).toEqual('US $');
+        expect(unit.label()).toEqual('US $');
     });
 
-    test("Unit measure label - unknown", () => {
+    test("Unit label - unknown", () => {
         var unit = new Unit(testReport(), 'iso4217:ZAR');
-        expect(unit.measureLabel()).toEqual('ZAR');
+        expect(unit.label()).toEqual('ZAR');
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -221,9 +221,7 @@ export function measureLabel(report, measure) {
     if (qname.namespace === NAMESPACE_ISO4217) {
         measure = i18next.t(`currencies:unitFormat${qname.localname}`, {defaultValue: qname.localname});
     } else if (measure.includes(':')) {
-        measure = titleCase(measure.split(':')[1]);
-    } else {
-        measure = titleCase(measure);
+        measure = measure.split(':')[1];
     }
     return measure;
 }

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -7,7 +7,7 @@ import i18next from "i18next";
 
 export const SHOW_FACT = 'SHOW_FACT';
 
-export const NAMESPACE_ISO4217 = 'http://www.xbrl.org/2003/iso4217'
+export const NAMESPACE_ISO4217 = 'http://www.xbrl.org/2003/iso4217';
 
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -6,6 +6,8 @@ import Decimal from "decimal.js";
 
 export const SHOW_FACT = 'SHOW_FACT';
 
+export const NAMESPACE_ISO4217 = 'http://www.xbrl.org/2003/iso4217'
+
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date
  * and time if the time component is not midnight.  Adjust specifies that a

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -2,6 +2,7 @@
 
 import moment from "moment";
 import Decimal from "decimal.js";
+import i18next from "i18next";
 
 
 export const SHOW_FACT = 'SHOW_FACT';
@@ -208,4 +209,21 @@ export function getIXHiddenLinkStyle(domNode) {
         }
     }
     return null;
+}
+
+/**
+ * Transforms measure qname into title case label (or currency symbol, if applicable).
+ * @return {String} Measure Label
+ */
+
+export function measureLabel(report, measure) {
+    const qname = report.qname(measure);
+    if (qname.namespace === NAMESPACE_ISO4217) {
+        measure = i18next.t(`currencies:unitFormat${qname.localname}`, {defaultValue: qname.localname});
+    } else if (measure.includes(':')) {
+        measure = titleCase(measure.split(':')[1]);
+    } else {
+        measure = titleCase(measure);
+    }
+    return measure;
 }

--- a/jest.config.json
+++ b/jest.config.json
@@ -1,0 +1,3 @@
+{
+  "testEnvironment": "jsdom"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "jest --roots=iXBRLViewerPlugin --env=jsdom",
+    "test": "jest --roots=iXBRLViewerPlugin",
     "test:puppeteer": "jest --roots=tests/puppeteer",
     "dev": "webpack --config iXBRLViewerPlugin/viewer/webpack.dev.js",
     "prod": "webpack --config iXBRLViewerPlugin/viewer/webpack.prod.js",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "jest --roots=iXBRLViewerPlugin",
-    "test:puppeteer": "jest --roots=tests/puppeteer",
+    "test:puppeteer": "jest --roots=tests/puppeteer --env=node",
     "dev": "webpack --config iXBRLViewerPlugin/viewer/webpack.dev.js",
     "prod": "webpack --config iXBRLViewerPlugin/viewer/webpack.prod.js",
     "stylelint": "stylelint iXBRLViewerPlugin/viewer/src/less/*.less",


### PR DESCRIPTION
#### Reason for change
Resolves #575

#### Description of change
Replaces the use of `measureLabel` (which simply took the first numerator of a complex unit for displaying a label) with `unitLabel`, which transforms simple or complex units into title-cased, more human-readable labels with currency symbols where applicable.

#### Steps to Test
Use example doc in linked issue to confirm complex units show completely and correctly:
![Screenshot 2023-11-29 at 12 29 14 PM](https://github.com/Arelle/ixbrl-viewer/assets/105066394/0a4fc57a-cfe0-4c4d-849e-64771f2aa03e)
![Screenshot 2023-11-29 at 12 29 08 PM](https://github.com/Arelle/ixbrl-viewer/assets/105066394/8d7c15e2-7460-4960-be6e-6f3b1d145fc9)



**review**:
@Arelle/arelle
@paulwarren-wk
