### PR TITLE
Add mypy, flake8, and nose2 tests to CI via tox

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -33,6 +33,9 @@ jobs:
           check-latest: true
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install .[dev]
-      - name: Test with nose2
-        run: nose2
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install .[dev]
+          pip install tox tox-gh-actions
+      - name: Test with tox
+        run: tox

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .idea
+.mypy_cache
+.pytest_cache
+.tox
 .vscode
+build
 node_modules/
 dist/
 __pycache__
@@ -8,3 +12,4 @@ iXBRLViewerPlugin/viewer/src/fonts/
 iXBRLViewerPlugin/viewer/src/less/generated/
 iXBRLViewerPlugin/_version.py
 /ixbrl-viewer*.tgz
+ixbrl_viewer.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 dev = [
+    'flake8==6.1.0',
     'lxml-stubs==0.4.0',
     'mypy==1.7.0',
     'nose2==0.14.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,10 @@ dependencies = [
 ]
 [project.optional-dependencies]
 dev = [
+    'lxml-stubs==0.4.0',
+    'mypy==1.7.0',
     'nose2==0.14.0',
-    'typing-extensions==4.8.0'
+    'typing-extensions==4.8.0',
 ]
 
 # https://setuptools.pypa.io/en/latest/userguide/entry_point.html#entry-points-for-plugins
@@ -60,3 +62,34 @@ namespaces = false
 [tool.setuptools_scm]
 tag_regex = "^(?:[\\w-]+-?)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"
 write_to = "iXBRLViewerPlugin/_version.py"
+
+[tool.mypy]
+# Warn when a # type: ignore comment does not specify any error codes
+enable_error_code = "ignore-without-code"
+python_version = "3.11"
+show_error_codes = true
+strict = true
+
+# --- ignore modules ---
+# remove from list below as each module is updated with type hinting
+[[tool.mypy.overrides]]
+module = [
+    'iXBRLViewerPlugin',
+    'iXBRLViewerPlugin.iXBRLViewer',
+    'iXBRLViewerPlugin.ui',
+    'iXBRLViewerPlugin.xhtmlserialize',
+    'tests.unit_tests.iXBRLViewerPlugin/mock_arelle',
+    'tests.unit_tests.iXBRLViewerPlugin/test_iXBRLViewer',
+    'tests.unit_tests.iXBRLViewerPlugin/test_xhtmlserialize',
+]
+ignore_errors = true
+
+# --- Modules lacking stubs ---
+# Add any module missing library stubs or not having
+# the py.typed marker here
+[[tool.mypy.overrides]]
+module = [
+    'ttk',
+    'arelle.*',
+]
+ignore_missing_imports = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[flake8]
+exclude = .venv,.git,.tox,docs,venv,bin,lib,deps,build
+doctests = True
+ignore =
+# closing bracket does not match indentation of opening bracket's line
+	E123,
+# continuation line over-indented for hanging indent
+	E126,
+# continuation line under-indented for visual indent
+	E128,
+# visually indented line with same indent as next logical line
+	E129,
+# whitespace after '('
+	E201,
+# whitespace before ')'
+	E202,
+# missing whitespace around arithmetic operator
+	E226,
+# missing whitespace after ':'
+	E231,
+# multiple spaces after ','
+	E241,
+# unexpected spaces around keyword / parameter equals
+	E251,
+# at least two spaces before inline comment
+	E261,
+# multiple spaces before keyword
+	E272,
+# expected 2 blank lines
+	E302,
+# line too long
+	E501,
+# statement ends with a semicolon
+	E703,
+# ambiguous variable name
+	E741,
+# undefined name (typically '_')
+	F821,
+# trailing whitespace
+	W291
+# blank line contains whitespace
+	W293
+# blank line at end of file
+	W391
+# line break before binary operator
+	W503,
+# invalid escape sequence '\d'
+	W605

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38, py39, py310, py311, typing
+envlist = py38, py39, py310, py311, lint, typing
 isolated_build = True
 skip_missing_interpreters = False
 
@@ -8,12 +8,18 @@ python =
   3.8: py38
   3.9: py39
   3.10: py310
-  3.11: py311, typing
+  3.11: py311, lint, typing
 
 [testenv]
 allowlist_externals = nose2
 commands =
   nose2
+
+[testenv:lint]
+allowlist_externals = flake8
+basepython = python3
+commands =
+  flake8 iXBRLViewerPlugin
 
 [testenv:typing]
 allowlist_externals = mypy

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py38, py39, py310, py311, typing
+isolated_build = True
+skip_missing_interpreters = False
+
+[gh-actions]
+python =
+  3.8: py38
+  3.9: py39
+  3.10: py310
+  3.11: py311, typing
+
+[testenv]
+allowlist_externals = nose2
+commands =
+  nose2
+
+[testenv:typing]
+allowlist_externals = mypy
+commands =
+  mypy iXBRLViewerPlugin tests --namespace-packages


### PR DESCRIPTION
#### Reason for change
Resolves #581

#### Description of change
Adds mypy type-checking, flake8 linting, and nose2 unit testing via CI via tox.

mypy and flake8 are initially configured to ignore existing failures, future changes can correct those failures while removing the associated ignore configuration.


#### Steps to Test
CI

**review**:
@Arelle/arelle
@paulwarren-wk
