### PR TITLE
Make arelle-release dependency optional

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          pip install .[dev]
+          pip install .[arelle,dev]
           pip install tox tox-gh-actions
       - name: Test with tox
         run: tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,13 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    'arelle_release==2.*',
     'lxml==4.*',
     'pycountry==22.*'
 ]
 [project.optional-dependencies]
+arelle = [
+    'arelle_release==2.*',
+]
 dev = [
     'flake8==6.1.0',
     'lxml-stubs==0.4.0',


### PR DESCRIPTION
#### Reason for change
The `ixbrl-viewer` python package is most often used in tandem with Arelle source or some other Arelle installation. Having `arelle-release` as a dependency of `ixbrl-viewer` causes an additional version of Arelle to be installed in `site-packages`.

This is likely a precedent for other non-built-in Arelle plugins going forward, so discussion on alternatives is encouraged.

#### Description of change
Move `arelle-release` dependency to optional `arelle` dependencies group.

#### Steps to Test
CI

**review**:
@Arelle/arelle
@paulwarren-wk
