### PR TITLE
Multi target document support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,8 +82,9 @@ the viewer.
 ### docSetFiles
 
 `docSetFiles` is a list of files in the document set.  It is used to load other
-documents in the document set into iframes in tabs in the viewer.  For single
-file, non-stub viewers, this property is not present.
+documents in the document set into iframes in tabs in the viewer.  
+
+`docSetFiles` is a list of relative URLs.
 
 ### targetReports
 

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -524,9 +524,13 @@ class iXBRLViewer:
         self.filingDocuments = None
         # This is an arbitrary ModelXbrl used for logging only
         self.logger_model = logger_model
+        self.filenames = set()
 
     def addFile(self, ivf):
+        if ivf.filename in self.filenames:
+            return
         self.files.append(ivf)
+        self.filenames.add(ivf.filename)
 
     def addFilingDoc(self, filingDocuments):
         self.filingDocuments = filingDocuments

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -390,7 +390,6 @@ class IXBRLViewerBuilder:
         self.taxonomyData["sourceReports"].append(sourceReport)
         return sourceReport
 
-
     def createViewer(self, scriptUrl: str = DEFAULT_VIEWER_PATH, useStubViewer: bool = False, showValidations: bool = True, packageDownloadURL: str = None) -> Optional[iXBRLViewer]:
         """
         Create an iXBRL file with XBRL data as a JSON blob, and script tags added.
@@ -408,7 +407,6 @@ class IXBRLViewerBuilder:
         self.roleMap.getPrefix(XbrlConst.parentChild, "pres")
         self.roleMap.getPrefix(XbrlConst.dimensionDefault, "d-d")
         self.roleMap.getPrefix(WIDER_NARROWER_ARCROLE, "w-n")
-
 
         sourceReportsByFiles = dict()
 
@@ -482,7 +480,6 @@ class IXBRLViewerBuilder:
                 localDoc: sorted(docTypes)
                 for localDoc, docTypes in localDocs.items()
             }
-
 
         self.taxonomyData["prefixes"] = self.nsmap.prefixmap
         self.taxonomyData["roles"] = self.roleMap.prefixmap

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -413,7 +413,7 @@ class IXBRLViewerBuilder:
         sourceReportsByFiles = dict()
 
         if useStubViewer:
-            iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, self.getStubDocumet()))
+            iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, self.getStubDocument()))
 
         for n, report in enumerate(self.reports):
             self.footnoteRelationshipSet = ModelRelationshipSet(report, "XBRL-footnotes")

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -95,6 +95,7 @@ class IXBRLViewerBuilder:
             "languages": {},
         }
         self.basenameSuffix = basenameSuffix
+        self.currentTargetReport = None
 
     def enableFeature(self, featureName: str):
         if featureName in self.taxonomyData["features"]:
@@ -148,21 +149,13 @@ class IXBRLViewerBuilder:
         if langCode not in self.taxonomyData["languages"]:
             self.taxonomyData["languages"][langCode] = self.makeLanguageName(langCode)
 
-    @property
-    def currentSourceReportData(self):
-        return self.taxonomyData["sourceReports"][-1]
-
-    @property
-    def currentReportData(self):
-        return self.currentSourceReportData["targetReports"][-1]
-            
     def addELR(self, report: ModelXbrl, elr):
         prefix = self.roleMap.getPrefix(elr)
-        if self.currentReportData.setdefault("roleDefs",{}).get(prefix, None) is None:
+        if self.currentTargetReport.setdefault("roleDefs",{}).get(prefix, None) is None:
             rts = report.roleTypes.get(elr, [])
             label = next((rt.definition for rt in rts if rt.definition is not None), None)
             if label is not None:
-                self.currentReportData["roleDefs"].setdefault(prefix,{})["en"] = label
+                self.currentTargetReport["roleDefs"].setdefault(prefix,{})["en"] = label
 
     def addConcept(self, report: ModelXbrl, concept, dimensionType = None):
         if concept is None:
@@ -170,7 +163,7 @@ class IXBRLViewerBuilder:
         labelsRelationshipSet = report.relationshipSet(XbrlConst.conceptLabel)
         labels = labelsRelationshipSet.fromModelObject(concept)
         conceptName = self.nsmap.qname(concept.qname)
-        if conceptName not in self.currentReportData["concepts"]:
+        if conceptName not in self.currentTargetReport["concepts"]:
             conceptData = {
                 "labels": {  }
             }
@@ -205,7 +198,7 @@ class IXBRLViewerBuilder:
                     conceptData['td'] = typedDomainName
                     self.addConcept(report, typedDomainElement)
 
-            self.currentReportData["concepts"][conceptName] = conceptData
+            self.currentTargetReport["concepts"][conceptName] = conceptData
 
     def treeWalk(self, rels, item, indent = 0):
         for r in rels.fromModelObject(item):
@@ -324,7 +317,7 @@ class IXBRLViewerBuilder:
                 if frel.toModelObject is not None:
                     factData.setdefault("fn", []).append(frel.toModelObject.id)
 
-        self.currentReportData["facts"][f.id] = factData
+        self.currentTargetReport["facts"][f.id] = factData
         self.addConcept(report, f.concept)
 
     def oimUnitString(self, unit):
@@ -348,10 +341,11 @@ class IXBRLViewerBuilder:
                 return "{}/{}".format(numeratorsString, denominatorsString)
         return numeratorsString
 
-    def addViewerToXMLDocument(self, xmlDocument, scriptUrl):
+    def addViewerData(self, viewerFile, scriptUrl):
+        viewerFile.xmlDocument = deepcopy(viewerFile.xmlDocument)
         taxonomyDataJSON = self.escapeJSONForScriptTag(json.dumps(self.taxonomyData, indent=1, allow_nan=False))
 
-        for child in xmlDocument.getroot():
+        for child in viewerFile.xmlDocument.getroot():
             if child.tag == '{http://www.w3.org/1999/xhtml}body':
                 for body_child in child:
                     if body_child.tag == '{http://www.w3.org/1999/xhtml}script' and body_child.get('type','') == 'application/x.ixbrl-viewer+json':
@@ -383,15 +377,19 @@ class IXBRLViewerBuilder:
         with open(os.path.join(os.path.dirname(__file__),"stubviewer.html")) as fin:
             return etree.parse(fin)
 
-    def addReport(self):
-        self.taxonomyData["sourceReports"].append({
-            "targetReports": [
-                {
-                    "concepts": {},
-                    "facts": {},
-                }
-            ]
-        })
+    def newTargetReport(self):
+        return {
+            "concepts": {},
+            "facts": {},
+        }
+
+    def addSourceReport(self):
+        sourceReport = {
+            "targetReports": []
+        }
+        self.taxonomyData["sourceReports"].append(sourceReport)
+        return sourceReport
+
 
     def createViewer(self, scriptUrl: str = DEFAULT_VIEWER_PATH, useStubViewer: bool = False, showValidations: bool = True, packageDownloadURL: str = None) -> Optional[iXBRLViewer]:
         """
@@ -411,59 +409,57 @@ class IXBRLViewerBuilder:
         self.roleMap.getPrefix(XbrlConst.dimensionDefault, "d-d")
         self.roleMap.getPrefix(WIDER_NARROWER_ARCROLE, "w-n")
 
-        # This is the document that we will embed the JSON taxonomy data in.
-        # This will be either the first document processed, or the stub document
-        xmlDocument = None
+
+        sourceReportsByFiles = dict()
+
+        if useStubViewer:
+            iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, self.getStubDocumet()))
 
         for n, report in enumerate(self.reports):
             self.footnoteRelationshipSet = ModelRelationshipSet(report, "XBRL-footnotes")
-            self.addReport()
+            self.currentTargetReport = self.newTargetReport()
             for f in report.facts:
                 self.addFact(report, f)
-            self.currentReportData["rels"] = self.getRelationships(report)
+            self.currentTargetReport["rels"] = self.getRelationships(report)
 
             docSetFiles = None
             report.info("viewer:info", "Creating iXBRL viewer (%d of %d)" % (n+1, len(self.reports)))
             if report.modelDocument.type == Type.INLINEXBRLDOCUMENTSET:
                 # Sort by object index to preserve order in which files were specified.
                 xmlDocsByFilename = {
-                    os.path.basename(self.outputFilename(doc.filepath)): deepcopy(doc.xmlDocument)
+                    os.path.basename(self.outputFilename(doc.filepath)): doc.xmlDocument
                     for doc in sorted(report.modelDocument.referencesDocument.keys(), key=lambda x: x.objectIndex)
                     if doc.type == Type.INLINEXBRL
                 }
                 docSetFiles = list(xmlDocsByFilename.keys())
 
-                if xmlDocument is None:
-                    if useStubViewer:
-                        xmlDocument = self.getStubDocument()
-                        iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, xmlDocument))
-                    else:
-                        xmlDocument = next(iter(xmlDocsByFilename.values()))
-
                 for filename, docSetXMLDoc in xmlDocsByFilename.items():
                     iv.addFile(iXBRLViewerFile(filename, docSetXMLDoc))
 
             elif useStubViewer:
-                if xmlDocument is None:
-                    xmlDocument = self.getStubDocument()
-                    iv.addFile(iXBRLViewerFile(DEFAULT_OUTPUT_NAME, xmlDocument))
                 filename = self.outputFilename(os.path.basename(report.modelDocument.filepath))
                 docSetFiles = [ filename ]
                 iv.addFile(iXBRLViewerFile(filename, report.modelDocument.xmlDocument))
 
             else:
+                srcFilename = self.outputFilename(os.path.basename(report.modelDocument.filepath))
+                docSetFiles = [ srcFilename ]
                 if len(self.reports) == 1:
                     # If there is only a single report, call the output file "xbrlviewer.html"
                     filename = "xbrlviewer.html"
                 else:
                     # Otherwise, preserve filenames
-                    filename = self.outputFilename(os.path.basename(report.modelDocument.filepath))
-                    docSetFiles = [ filename ]
-                if xmlDocument is None:
-                    xmlDocument = deepcopy(report.modelDocument.xmlDocument)
-                    iv.addFile(iXBRLViewerFile(filename, xmlDocument))
-                else:
-                    iv.addFile(iXBRLViewerFile(filename, report.modelDocument.xmlDocument))
+                    filename = srcFilename
+                iv.addFile(iXBRLViewerFile(filename, report.modelDocument.xmlDocument))
+
+            docSetKey = frozenset(docSetFiles)
+            sourceReport = sourceReportsByFiles.get(docSetKey)
+            if sourceReport is None:
+                sourceReport = self.addSourceReport()
+                sourceReportsByFiles[docSetKey] = sourceReport
+                sourceReport["docSetFiles"] = list(urllib.parse.quote(f) for f in docSetFiles)
+
+            sourceReport["targetReports"].append(self.currentTargetReport)
 
             localDocs = defaultdict(set)
             for path, doc in report.urlDocs.items():
@@ -482,13 +478,11 @@ class IXBRLViewerBuilder:
                             linkbaseIdentifed = True
                     if not linkbaseIdentifed:
                         localDocs[doc.basename].add(UNRECOGNIZED_LINKBASE_LOCAL_DOCUMENTS_TYPE)
-            self.currentReportData["localDocs"] = {
+            self.currentTargetReport["localDocs"] = {
                 localDoc: sorted(docTypes)
                 for localDoc, docTypes in localDocs.items()
             }
 
-            if docSetFiles is not None:
-                self.currentSourceReportData["docSetFiles"] = list(urllib.parse.quote(f) for f in docSetFiles)
 
         self.taxonomyData["prefixes"] = self.nsmap.prefixmap
         self.taxonomyData["roles"] = self.roleMap.prefixmap
@@ -504,7 +498,7 @@ class IXBRLViewerBuilder:
             iv.addFilingDoc(filingDocZipPath)
             self.taxonomyData["filingDocuments"] = filingDocZipName
 
-        if not self.addViewerToXMLDocument(xmlDocument, scriptUrl):
+        if not self.addViewerData(iv.files[0], scriptUrl):
             return None
 
         return iv

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -169,8 +169,8 @@ See COPYRIGHT.md for copyright information
           </div>
 
           <div class="filter-info">
-            <span id="matching-concepts-count">?</span>
-            <span data-i18n="inspector.matchingConcepts"> matching concept(s)</span>
+            <span id="matching-facts-count">?</span>
+            <span data-i18n="inspector.matchingFacts"> matching facts(s)</span>
           </div>
         </div>
       </div>

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -47,7 +47,7 @@
     "highlight": "Highlight",
     "initializing": "Initializing",
     "loadingViewer": "Loading iXBRL Viewer",
-    "matchingConcepts": " matching concept(s)",
+    "matchingFacts": " matching facts(s)",
     "namespaces": "Namespaces",
     "narrowerAnchor": "Narrower anchors",
     "negative": "Negative",

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -47,7 +47,7 @@
     "highlight": "Destacar",
     "initializing": "",
     "loadingViewer": "Preparando el visor iXBRL",
-    "matchingConcepts": "",
+    "matchingFacts": "",
     "namespaces": "",
     "narrowerAnchor": "Anclaje angosto",
     "negative": "",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -436,7 +436,7 @@ export class Inspector {
             $(".text", overlay).text(i18next.t("search.tryAgainDifferentKeywords"));
             overlay.show();
         }
-        $("#matching-concepts-count").text(results.length);
+        $("#matching-facts-count").text(results.length);
         /* Don't highlight search results if there's no search string */
         if (spec.searchString != "") {
             this._viewer.highlightRelatedFacts(results.map(r => r.fact));

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1,7 +1,7 @@
 // See COPYRIGHT.md for copyright information
 
 import $ from 'jquery'
-import { formatNumber, wrapLabel, truncateLabel, runGenerator, SHOW_FACT, viewerUniqueId } from "./util.js";
+import { formatNumber, wrapLabel, truncateLabel, runGenerator, SHOW_FACT, HIGHLIGHT_COLORS, viewerUniqueId } from "./util.js";
 import { ReportSearch } from "./search.js";
 import { Calculation } from "./calculations.js";
 import { IXBRLChart } from './chart.js';
@@ -256,7 +256,7 @@ export class Inspector {
         for (const [i, name] of key.entries()) {
             $("<div>")
                 .addClass("item")
-                .append($("<span></span>").addClass("sample").addClass("sample-" + i))
+                .append($("<span></span>").addClass("sample").addClass("sample-" + (i % HIGHLIGHT_COLORS)))
                 .append($("<span></span>").text(name))
                 .appendTo($(".highlight-key .items"));
         }

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -9,6 +9,9 @@ export const SHOW_FACT = 'SHOW_FACT';
 
 export const NAMESPACE_ISO4217 = 'http://www.xbrl.org/2003/iso4217';
 
+// The number of distinct highlight colors defined in inspector.less
+export const HIGHLIGHT_COLORS = 3;
+
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date
  * and time if the time component is not midnight.  Adjust specifies that a

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -3,9 +3,8 @@
 import $ from 'jquery'
 import { numberMatchSearch, fullDateMatch } from './number-matcher.js'
 import { TableExport } from './tableExport.js'
-import { escapeRegex, viewerUniqueId } from './util.js'
 import { IXNode } from './ixnode.js';
-import { getIXHiddenLinkStyle, runGenerator } from './util.js';
+import { getIXHiddenLinkStyle, runGenerator, escapeRegex, viewerUniqueId, HIGHLIGHT_COLORS } from './util.js';
 import { DocOrderIndex } from './docOrderIndex.js';
 import { MessageBox } from './messagebox.js';
 
@@ -751,7 +750,7 @@ export class Viewer {
     highlightAllTags(on, namespaceGroups) {
         const groups = {};
         $.each(namespaceGroups, function (i, ns) {
-            groups[ns] = i;
+            groups[ns] = i % HIGHLIGHT_COLORS;
         });
         const reportSet = this._reportSet;
         const viewer = this;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -109,7 +109,7 @@ export class Viewer {
         if (this._reportSet.isMultiDocumentViewer()) {
             $('#ixv .ixds-tabs').show();
             for (const [i, doc] of this._reportSet.reportFiles().entries()) {
-                $('<div class="tab">')
+                $('<div class="tab"></div>')
                     .text(doc.file)
                     .prop('title', doc.file)
                     .data('ix-doc-id', i)


### PR DESCRIPTION
#### Reason for change

To support an XBRL feature used by a growing number of jurisdictions

#### Description of change

The viewer builder will now include all target documents that have been loaded by Arelle, and the viewer no longer ignores non-default target documents when pre-processing.

The key changes on the builder side are to create a single "source report" for a given set iXBRL document set, and to change where we do the `deepcopy` of the XML document in order to ensure that the addition of missing ID attributes for all targets make it into the output.

This PR also:

* Fixes namespace highlighting if there are more than three namespaces
* Changes the search results count to refer to "facts" rather than "concepts"

#### Steps to Test

Create a viewer for any document with multiple target documents.  For example, this filing:

https://filings.xbrl.org/filing/529900T6WNZXD2R3JW38-2021-09-30-ESEF-DK-0 (base taxonomies [here](https://erhvervsstyrelsen.dk/vejledning-teknisk-vejledning-og-dokumentation-regnskab-20-taksonomier-historiske))

Recent versions of Arelle will load all targets by default.

Check the namespaces loaded into the viewer (note that there's only one non-hidden, DKGAAP concept in the above example).

**review**:
@Arelle/arelle
@paulwarren-wk
