### PR TITLE
Highlight scaled and absolutely positioned facts within tables

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -19,9 +19,9 @@ jobs:
           - ubuntu-22.04
           - windows-2022
         node-version:
-          - '16'
           - '18'
           - '20'
+          - '21'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.1

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -18,9 +18,9 @@ jobs:
           - ubuntu-22.04
           - windows-2022
         node-version:
-          - '16'
           - '18'
           - '20'
+          - '21'
         python-version:
           - '3.12'
     runs-on: ${{ matrix.os }}

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -258,10 +258,10 @@ class iXBRLViewerLocalViewer(LocalViewer):
             _fileExists = False
             if os.path.exists(os.path.join(_fileDir, _file)):
                 _fileExists = True
-            elif "/" in _file and os.path.exists(os.path.join(_fileDir, os.path.filepart(_file))):
+            elif "/" in _file and os.path.exists(os.path.join(_fileDir, os.path.basename(_file))):
                 # xhtml in a subdirectory for output files may refer to an image file in parent directory
                 _fileExists = True
-                _file = os.path.filepart(_file)
+                _file = os.path.basename(_file)
             if not _fileExists:
                 self.cntlr.addToLog("http://localhost:{}/{}".format(self.port, file), messageCode="localViewer:fileNotFound", level=logging.DEBUG)
             return static_file(_file, root=_fileDir, headers=self.noCacheHeaders)  # extra_headers modification to py-bottle

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 import traceback
 from optparse import OptionGroup, OptionParser
-from typing import Optional, Union
 
 from arelle import Cntlr
 from arelle.LocalViewer import LocalViewer
@@ -96,13 +95,14 @@ def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
 
 def generateViewer(
         cntlr: Cntlr,
-        saveViewerDest: Union[io.BytesIO, str],
+        saveViewerDest: io.BytesIO | str | None,
         viewerURL: str = DEFAULT_VIEWER_PATH,
         showValidationMessages: bool = False,
         useStubViewer: bool = False,
         zipViewerOutput: bool = False,
-        features: Optional[list[str]] = None,
-        packageDownloadURL: str = None):
+        features: list[str] | None = None,
+        packageDownloadURL: str | None = None,
+) -> None:
     """
     Generate and save a viewer at the given destination (file, directory, or in-memory file) with the given viewer URL.
     If the viewer URL is a location on the local file system, a copy will be placed included in the output destination.
@@ -170,7 +170,7 @@ def getAbsoluteViewerPath(saveViewerPath: str, relativeViewerPath: str) -> str:
     return os.path.join(saveViewerDir, relativeViewerPath)
 
 
-def getFeaturesFromOptions(options: Union[argparse.Namespace, OptionParser]):
+def getFeaturesFromOptions(options: argparse.Namespace | OptionParser):
     return [
         featureConfig.key
         for featureConfig in FEATURE_CONFIGS

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -115,6 +115,8 @@ def generateViewer(
     :param features: List of feature names to enable via generated JSON data.
     """
     # extend XBRL-loaded run processing for this option
+    if saveViewerDest is None:
+        return
     if (cntlr.modelManager is None 
         or len(cntlr.modelManager.loadedModelXbrls) == 0 
         or any(not mx.modelDocument for mx in cntlr.modelManager.loadedModelXbrls)):
@@ -142,15 +144,13 @@ def generateViewer(
             copyScriptPath = viewerURL
             viewerURL = os.path.basename(viewerURL)
     try:
-        out = saveViewerDest
-        if out:
-            viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.loadedModelXbrls)
-            if features:
-                for feature in features:
-                    viewerBuilder.enableFeature(feature)
-            iv = viewerBuilder.createViewer(scriptUrl=viewerURL, showValidations=showValidationMessages, useStubViewer=useStubViewer, packageDownloadURL=packageDownloadURL)
-            if iv is not None:
-                iv.save(out, zipOutput=zipViewerOutput, copyScriptPath=copyScriptPath)
+        viewerBuilder = IXBRLViewerBuilder(cntlr.modelManager.loadedModelXbrls)
+        if features:
+            for feature in features:
+                viewerBuilder.enableFeature(feature)
+        iv = viewerBuilder.createViewer(scriptUrl=viewerURL, showValidations=showValidationMessages, useStubViewer=useStubViewer, packageDownloadURL=packageDownloadURL)
+        if iv is not None:
+            iv.save(saveViewerDest, zipOutput=zipViewerOutput, copyScriptPath=copyScriptPath)
     except IXBRLViewerBuilderError as ex:
         print(ex)
     except Exception as ex:

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -152,7 +152,7 @@ def generateViewer(
             if iv is not None:
                 iv.save(out, zipOutput=zipViewerOutput, copyScriptPath=copyScriptPath)
     except IXBRLViewerBuilderError as ex:
-        print(ex.message)
+        print(ex)
     except Exception as ex:
         cntlr.addToLog("Exception {} \nTraceback {}".format(ex, traceback.format_tb(sys.exc_info()[2])))
 

--- a/iXBRLViewerPlugin/constants.py
+++ b/iXBRLViewerPlugin/constants.py
@@ -13,7 +13,8 @@ CONFIG_ZIP_OUTPUT = 'iXBRLViewerZipOutput'
 
 DEFAULT_LAUNCH_ON_LOAD = True
 DEFAULT_OUTPUT_NAME = 'ixbrlviewer.html'
-DEFAULT_VIEWER_PATH = os.path.join(os.path.dirname(__file__), "viewer", "dist", "ixbrlviewer.js")
+DEFAULT_JS_FILENAME = 'ixbrlviewer.js'
+DEFAULT_VIEWER_PATH = os.path.join(os.path.dirname(__file__), "viewer", "dist", DEFAULT_JS_FILENAME)
 
 FEATURE_CONFIGS = [
     FeatureConfig(

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -12,7 +12,6 @@ import urllib.parse
 import zipfile
 from collections import defaultdict
 from copy import deepcopy
-from typing import Optional, Union
 
 import pycountry
 from arelle import XbrlConst
@@ -390,7 +389,13 @@ class IXBRLViewerBuilder:
         self.taxonomyData["sourceReports"].append(sourceReport)
         return sourceReport
 
-    def createViewer(self, scriptUrl: str = DEFAULT_VIEWER_PATH, useStubViewer: bool = False, showValidations: bool = True, packageDownloadURL: str = None) -> Optional[iXBRLViewer]:
+    def createViewer(
+            self,
+            scriptUrl: str = DEFAULT_VIEWER_PATH,
+            useStubViewer: bool = False,
+            showValidations: bool = True,
+            packageDownloadURL: str | None = None,
+    ) -> iXBRLViewer | None:
         """
         Create an iXBRL file with XBRL data as a JSON blob, and script tags added.
         :param scriptUrl: The `src` value of the script tag that loads the viewer script.
@@ -526,7 +531,7 @@ class iXBRLViewer:
     def addFilingDoc(self, filingDocuments):
         self.filingDocuments = filingDocuments
 
-    def save(self, destination: Union[io.BytesIO, str], zipOutput: bool = False, copyScriptPath: Optional[str] = None):
+    def save(self, destination: io.BytesIO | str, zipOutput: bool = False, copyScriptPath: str | None = None):
         """
         Save the iXBRL viewer.
         :param destination: The target that viewer data/files will be written to (path to file/directory, or a file object itself).

--- a/iXBRLViewerPlugin/ui.py
+++ b/iXBRLViewerPlugin/ui.py
@@ -10,8 +10,9 @@ import os
 
 from .constants import CONFIG_FEATURE_PREFIX, CONFIG_FILE_DIRECTORY, CONFIG_LAUNCH_ON_LOAD, \
     CONFIG_OUTPUT_FILE, CONFIG_SCRIPT_URL, CONFIG_ZIP_OUTPUT, DEFAULT_LAUNCH_ON_LOAD, \
-    DEFAULT_VIEWER_PATH, GUI_FEATURE_CONFIGS
+    GUI_FEATURE_CONFIGS
 
+UNSET_SCRIPT_URL = ''
 
 class BaseViewerDialog(Toplevel):
     """
@@ -28,7 +29,7 @@ class BaseViewerDialog(Toplevel):
             featureVar.set(self.cntlr.config.setdefault(f'{CONFIG_FEATURE_PREFIX}{featureConfig.key}', featureConfig.guiDefault))
             self._features[featureConfig.key] = featureVar
         self._scriptUrl = StringVar()
-        self._scriptUrl.set(self.cntlr.config.setdefault(CONFIG_SCRIPT_URL, DEFAULT_VIEWER_PATH))
+        self._scriptUrl.set(self.cntlr.config.setdefault(CONFIG_SCRIPT_URL, UNSET_SCRIPT_URL))
 
     def addButtons(self, frame: Frame, x: int, y: int) -> int:
         """
@@ -56,7 +57,7 @@ class BaseViewerDialog(Toplevel):
         :return: Row `y` that the last field was added on
         """
         y += 1
-        scriptUrlLabel = Label(frame, text="Script URL")
+        scriptUrlLabel = Label(frame, text="Script URL (leave blank for default)")
         scriptUrlEntry = Entry(frame, textvariable=self._scriptUrl, width=80)
         scriptUrlLabel.grid(row=y, column=0, sticky=W, pady=3, padx=3)
         scriptUrlEntry.grid(row=y, column=1, columnspan=2, sticky=EW, pady=3, padx=3)
@@ -247,6 +248,6 @@ class SettingsDialog(BaseViewerDialog):
         Resets dialog variable values to default values
         """
         self._launchOnLoad.set(DEFAULT_LAUNCH_ON_LOAD)
-        self._scriptUrl.set(DEFAULT_VIEWER_PATH)
+        self._scriptUrl.set(UNSET_SCRIPT_URL)
         for featureConfig in GUI_FEATURE_CONFIGS:
             self._features[featureConfig.key].set(featureConfig.guiDefault)

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -271,14 +271,12 @@ export class Viewer {
         /* Otherwise, insert a <span> as wrapper */
         if (nodes.length == 0) {
             nodes.push(this._wrapNode(domNode));
-
-            // Create a list of the wrapper node, and all absolutely positioned
-            // descendants.
-            for (const e of domNode.querySelectorAll("*")) { 
-                if (getComputedStyle(e).getPropertyValue('position') === "absolute") { 
-                    nodes.push(e);
-                } 
-            }
+        }
+        // Create a list of the wrapper node, and all absolutely positioned descendants.
+        for (const e of nodes[0].querySelectorAll("*")) { 
+            if (getComputedStyle(e).getPropertyValue('position') === "absolute") { 
+                nodes.push(e);
+            } 
         }
         for (const [i, n] of nodes.entries()) {
             // getBoundingClientRect blocks on layout, so only do it if we've actually got absolute nodes

--- a/iXBRLViewerPlugin/viewer/src/less/common.less
+++ b/iXBRLViewerPlugin/viewer/src/less/common.less
@@ -2,12 +2,12 @@
 
 /* Styles common to both inspector and highlighting used within iframe */
 .linked-highlight-text {
-  outline: dashed 2px @linked-fact;
-  outline-offset: 1px;
+  outline: dashed 0.125em @linked-fact;
+  outline-offset: 0.0625em;
 }
 
 .linked-highlight-cell {
   .linked-highlight-text();
 
-  outline-offset: -1px;
+  outline-offset: -0.0625em;
 }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -1064,8 +1064,8 @@
     color: @primary;
 
     &:hover {
-      outline: solid 2px @linked-fact;
-      outline-offset: 1px;
+      outline: solid 0.125em @linked-fact;
+      outline-offset: 0.0625em;
     }
   }
 

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -45,15 +45,15 @@ div,
 span {
   &:not(.ixbrl-no-highlight) {
     &.ixbrl-selected {
-      outline: solid 2px @primary-focus;
-      outline-offset: 1px;
+      outline: solid 0.125em @primary-focus;
+      outline-offset: 0.0625em;
     }
 
     &.ixbrl-element,
     &.ixbrl-sub-element {
       &:hover:not(.ixbrl-selected) {
-        outline: dashed 2px @primary-focus;
-        outline-offset: 1px;
+        outline: dashed 0.125em @primary-focus;
+        outline-offset: 0.0625em;
       }
     }
   }
@@ -65,10 +65,10 @@ span {
     cursor: pointer;
 
     &.ixbrl-related {
-      outline: dashed 2px @related-fact;
+      outline: dashed 0.125em @related-fact;
 
       &:not(td, th) {
-        outline-offset: 1px;
+        outline-offset: 0.0625em;
       }
     }
   }
@@ -78,19 +78,19 @@ td,
 th {
   &:not(.ixbrl-no-highlight) {
     &.ixbrl-selected {
-      outline: solid 2px @primary-focus !important;
-      outline-offset: -1px !important;
+      outline: solid 0.125em @primary-focus !important;
+      outline-offset: -0.0625em !important;
     }
 
     &.ixbrl-element:hover:not(.ixbrl-selected),
     &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
-      outline: dashed 2px @primary-focus !important;
-      outline-offset: -1px !important;
+      outline: dashed 0.125em @primary-focus !important;
+      outline-offset: -0.0625em !important;
     }
   }
 
   &.ixbrl-related {
-    outline-offset: -1px;
+    outline-offset: -0.0625em;
   }
 }
 
@@ -103,7 +103,7 @@ td.ixbrl-related.ixbrl-linked-highlight:not(.ixbrl-no-highlight),
 td.ixbrl-linked-highlight:not(.ixbrl-no-highlight) {
   .linked-highlight-cell();
 
-  outline-offset: -1px;
+  outline-offset: -0.0625em;
 }
 
 div.ixbrl-table-handle {

--- a/samples/build-viewer.py
+++ b/samples/build-viewer.py
@@ -58,7 +58,7 @@ class CntlrCreateViewer(Cntlr.Cntlr):
         try:
             generateViewer(self, outPath, scriptUrl, showValidationMessages=True, useStubViewer=useStubViewer, features=features)
         except iXBRLViewerPlugin.iXBRLViewer.IXBRLViewerBuilderError as e:
-            print(e.message)
+            print(e)
             sys.exit(1)
 
 parser = argparse.ArgumentParser(description="Create iXBRL Viewer instances")


### PR DESCRIPTION
#### Reason for change
Fact highlighting of absolutely positioned content doesn't apply to facts within tables. Additionally, the highlight outline width is set to a pixel size and doesn't adjust for documents that use CSS scale transforms.

#### Description of change
* Use em sizes to define fact highlight outlines for scaled documents.
* Highlight fact content that is absolutely positioned within tables.
* Fix `AttributeError: 'IXBRLViewerBuilderError' object has no attribute 'message'`
* Use a default empty string script path (for the built-in script file) in the GUI instead of an absolute path so users can have multiple versions of Arelle and ixbrl-viewer (frozen build and Python source) on the same machine.
* Explicitly exit generation early if destination is None.
* Replace nonexistent `os.path.filepart` method reference.
* Update Node versions used for CI tests to current active versions (maintenance, LTS, and current.)

#### Steps to Test
* Test internal doc.

**review**:
@Arelle/arelle
@paulwarren-wk
