### PR TITLE
Tolerate invalid enumeration values

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -265,11 +265,15 @@ class IXBRLViewerBuilder:
             factData["v"] = None
         elif f.concept is not None and f.concept.isEnumeration:
             qnEnums = f.xValue
-            if not isinstance(qnEnums, list):
-                qnEnums = (qnEnums,)
-            factData["v"] = " ".join(self.nsmap.qname(qn) for qn in qnEnums)
-            for qn in qnEnums:
-                self.addConcept(report, report.qnameConcepts.get(qn))
+            if qnEnums is None:
+                factData["v"] = f.value
+                factData["err"] = 'INVALID_IX_VALUE'
+            else:
+                if not isinstance(qnEnums, list):
+                    qnEnums = (qnEnums,)
+                factData["v"] = " ".join(self.nsmap.qname(qn) for qn in qnEnums)
+                for qn in qnEnums:
+                    self.addConcept(report, report.qnameConcepts.get(qn))
         else:
             factData["v"] = f.value 
             if f.value == INVALIDixVALUE:


### PR DESCRIPTION
#### Reason for change

Fixes #612

#### Description of change

If an enumeration value is syntactically invalid, don't attempt to treat it is a QName, but instead set the `err` property on the fact data, so that "invalid value" is displayed in the fact inspector.

#### Steps to Test

Test document on #612.

* Viewer can now be created without error for this document.
* Check both `DerivativeAssetStatementOfFinancialPositionExtensibleEnumeration` facts:
    * First should say "invalid value"
    * Second should work correctly, and display a label from the taxonomy.

**review**:
@Arelle/arelle
@paulwarren-wk
