### PR TITLE
Log error and abort generation if viewer script does not exist

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -183,14 +183,14 @@ def getFeaturesFromOptions(options: argparse.Namespace | OptionParser):
 
 def iXBRLViewerCommandLineXbrlRun(cntlr, options, *args, **kwargs):
     generateViewer(
-        cntlr,
-        options.saveViewerDest or kwargs.get("responseZipStream"),
-        options.viewerURL,
-        options.validationMessages,
-        options.useStubViewer,
-        options.zipViewerOutput,
-        getFeaturesFromOptions(options),
-        options.packageDownloadURL,
+        cntlr=cntlr,
+        saveViewerDest=options.saveViewerDest or kwargs.get("responseZipStream"),
+        viewerURL=options.viewerURL,
+        showValidationMessages=options.validationMessages,
+        useStubViewer=options.useStubViewer,
+        zipViewerOutput=options.zipViewerOutput,
+        features=getFeaturesFromOptions(options),
+        packageDownloadURL=options.packageDownloadURL,
     )
 
 
@@ -207,9 +207,9 @@ def iXBRLViewerSaveCommand(cntlr):
     dialog.render()
     if dialog.accepted and dialog.filename():
         generateViewer(
-            cntlr,
-            dialog.filename(),
-            dialog.scriptUrl() or DEFAULT_VIEWER_PATH,
+            cntlr=cntlr,
+            saveViewerDest=dialog.filename(),
+            viewerURL=dialog.scriptUrl() or DEFAULT_VIEWER_PATH,
             zipViewerOutput=dialog.zipViewerOutput(),
             features=dialog.features()
         )
@@ -287,7 +287,7 @@ def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
             if cntlr.config.setdefault(f'{CONFIG_FEATURE_PREFIX}{c.key}', False)
         ]
         generateViewer(
-            cntlr,
+            cntlr=cntlr,
             saveViewerDest=tempViewer.name,
             viewerURL=cntlr.config.get(CONFIG_SCRIPT_URL) or DEFAULT_VIEWER_PATH,
             useStubViewer=True,

--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import traceback
 from optparse import OptionGroup, OptionParser
+from pathlib import Path
 
 from arelle import Cntlr
 from arelle.LocalViewer import LocalViewer
@@ -292,9 +293,10 @@ def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
             useStubViewer=True,
             features=features
         )
-        localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))
-        localhost = localViewer.init(cntlr, tempViewer.name)
-        webbrowser.open(f'{localhost}/{viewer_file_name}')
+        if Path(tempViewer.name, viewer_file_name).exists():
+            localViewer = iXBRLViewerLocalViewer("iXBRL Viewer",  os.path.dirname(__file__))
+            localhost = localViewer.init(cntlr, tempViewer.name)
+            webbrowser.open(f'{localhost}/{viewer_file_name}')
     except Exception as ex:
         modelXbrl.error(
             EXCEPTION_MESSAGE_CODE,

--- a/iXBRLViewerPlugin/constants.py
+++ b/iXBRLViewerPlugin/constants.py
@@ -7,6 +7,7 @@ from .featureConfig import FeatureConfig
 CONFIG_FEATURE_PREFIX = 'iXBRLViewerFeature_'
 CONFIG_FILE_DIRECTORY = 'iXBRLViewerFileDir'
 CONFIG_LAUNCH_ON_LOAD = 'iXBRLViewerLaunchOnLoad'
+CONFIG_COPY_SCRIPT = 'iXBRLViewerCopyScript'
 CONFIG_OUTPUT_FILE = 'iXBRLViewerOutputFile'
 CONFIG_SCRIPT_URL = 'iXBRLViewerScriptURL'
 CONFIG_ZIP_OUTPUT = 'iXBRLViewerZipOutput'
@@ -16,6 +17,7 @@ EXCEPTION_MESSAGE_CODE = 'viewer:exception'
 INFO_MESSAGE_CODE = 'viewer:info'
 
 DEFAULT_LAUNCH_ON_LOAD = True
+DEFAULT_COPY_SCRIPT = True
 DEFAULT_OUTPUT_NAME = 'ixbrlviewer.html'
 DEFAULT_JS_FILENAME = 'ixbrlviewer.js'
 DEFAULT_VIEWER_PATH = os.path.join(os.path.dirname(__file__), "viewer", "dist", DEFAULT_JS_FILENAME)

--- a/iXBRLViewerPlugin/constants.py
+++ b/iXBRLViewerPlugin/constants.py
@@ -11,6 +11,10 @@ CONFIG_OUTPUT_FILE = 'iXBRLViewerOutputFile'
 CONFIG_SCRIPT_URL = 'iXBRLViewerScriptURL'
 CONFIG_ZIP_OUTPUT = 'iXBRLViewerZipOutput'
 
+ERROR_MESSAGE_CODE = 'viewer:error'
+EXCEPTION_MESSAGE_CODE = 'viewer:exception'
+INFO_MESSAGE_CODE = 'viewer:info'
+
 DEFAULT_LAUNCH_ON_LOAD = True
 DEFAULT_OUTPUT_NAME = 'ixbrlviewer.html'
 DEFAULT_JS_FILENAME = 'ixbrlviewer.js'

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -23,7 +23,7 @@ from arelle.UrlUtil import isHttpUrl
 from arelle.ValidateXbrlCalcs import inferredDecimals
 from lxml import etree
 
-from .constants import DEFAULT_OUTPUT_NAME, DEFAULT_VIEWER_PATH, FEATURE_CONFIGS
+from .constants import DEFAULT_OUTPUT_NAME, DEFAULT_VIEWER_PATH, ERROR_MESSAGE_CODE, FEATURE_CONFIGS, INFO_MESSAGE_CODE
 from .xhtmlserialize import XHTMLSerializer
 
 
@@ -352,7 +352,7 @@ class IXBRLViewerBuilder:
             if child.tag == '{http://www.w3.org/1999/xhtml}body':
                 for body_child in child:
                     if body_child.tag == '{http://www.w3.org/1999/xhtml}script' and body_child.get('type','') == 'application/x.ixbrl-viewer+json':
-                        self.logger_model.error("viewer:error", "File already contains iXBRL viewer")
+                        self.logger_model.error(ERROR_MESSAGE_CODE, "File already contains iXBRL viewer")
                         return False
 
                 child.append(etree.Comment("BEGIN IXBRL VIEWER EXTENSIONS"))
@@ -430,7 +430,7 @@ class IXBRLViewerBuilder:
             self.currentTargetReport["rels"] = self.getRelationships(report)
 
             docSetFiles = None
-            report.info("viewer:info", "Creating iXBRL viewer (%d of %d)" % (n+1, len(self.reports)))
+            report.info(INFO_MESSAGE_CODE, "Creating iXBRL viewer (%d of %d)" % (n+1, len(self.reports)))
             if report.modelDocument.type == Type.INLINEXBRLDOCUMENTSET:
                 # Sort by object index to preserve order in which files were specified.
                 xmlDocsByFilename = {
@@ -553,15 +553,15 @@ class iXBRLViewer:
                 fileMode = 'w'
             elif destination.endswith(os.sep):
                 # Looks like a directory, but isn't one
-                self.logger_model.error("viewer:error", "Directory %s does not exist" % destination)
+                self.logger_model.error(ERROR_MESSAGE_CODE, "Directory %s does not exist" % destination)
                 return
             elif not os.path.isdir(os.path.dirname(os.path.abspath(destination))):
                 # Directory part of filename doesn't exist
-                self.logger_model.error("viewer:error", "Directory %s does not exist" % os.path.dirname(os.path.abspath(destination)))
+                self.logger_model.error(ERROR_MESSAGE_CODE, "Directory %s does not exist" % os.path.dirname(os.path.abspath(destination)))
                 return
             elif not destination.endswith('.zip'):
                 # File extension isn't a zip
-                self.logger_model.error("viewer:error", "File extension %s is not a zip" % os.path.splitext(destination)[0])
+                self.logger_model.error(ERROR_MESSAGE_CODE, "File extension %s is not a zip" % os.path.splitext(destination)[0])
                 return
             else:
                 file = destination
@@ -569,50 +569,50 @@ class iXBRLViewer:
 
             with zipfile.ZipFile(file, fileMode, zipfile.ZIP_DEFLATED, True) as zout:
                 for f in self.files:
-                    self.logger_model.info("viewer:info", "Saving in output zip %s" % f.filename)
+                    self.logger_model.info(INFO_MESSAGE_CODE, "Saving in output zip %s" % f.filename)
                     with zout.open(f.filename, "w") as fout:
                         writer = XHTMLSerializer(fout)
                         writer.serialize(f.xmlDocument)
                 if self.filingDocuments:
                     filename = os.path.basename(self.filingDocuments)
-                    self.logger_model.info("viewer:info", "Writing %s" % filename)
+                    self.logger_model.info(INFO_MESSAGE_CODE, "Writing %s" % filename)
                     zout.write(self.filingDocuments, filename)
                 if copyScriptPath is not None:
                     scriptSrc = os.path.join(destination, copyScriptPath)
-                    self.logger_model.info("viewer:info", "Writing script from %s" % scriptSrc)
+                    self.logger_model.info(INFO_MESSAGE_CODE, "Writing script from %s" % scriptSrc)
                     zout.write(scriptSrc, os.path.basename(copyScriptPath))
         elif os.path.isdir(destination):
             # If output is a directory, write each file in the doc set to that
             # directory using its existing filename
             for f in self.files:
                 filename = os.path.join(destination, f.filename)
-                self.logger_model.info("viewer:info", "Writing %s" % filename)
+                self.logger_model.info(INFO_MESSAGE_CODE, "Writing %s" % filename)
                 with open(filename, "wb") as fout:
                     writer = XHTMLSerializer(fout)
                     writer.serialize(f.xmlDocument)
             if self.filingDocuments:
                 filename = os.path.basename(self.filingDocuments)
-                self.logger_model.info("viewer:info", "Writing %s" % filename)
+                self.logger_model.info(INFO_MESSAGE_CODE, "Writing %s" % filename)
                 shutil.copy2(self.filingDocuments, os.path.join(destination, filename))
             if copyScriptPath is not None:
                 self._copyScript(destination, copyScriptPath)
         else:
             if len(self.files) > 1:
-                self.logger_model.error("viewer:error", "More than one file in input, but output is not a directory")
+                self.logger_model.error(ERROR_MESSAGE_CODE, "More than one file in input, but output is not a directory")
             elif destination.endswith(os.sep):
                 # Looks like a directory, but isn't one
-                self.logger_model.error("viewer:error", "Directory %s does not exist" % destination)
+                self.logger_model.error(ERROR_MESSAGE_CODE, "Directory %s does not exist" % destination)
             elif not os.path.isdir(os.path.dirname(os.path.abspath(destination))):
                 # Directory part of filename doesn't exist
-                self.logger_model.error("viewer:error", "Directory %s does not exist" % os.path.dirname(os.path.abspath(destination)))
+                self.logger_model.error(ERROR_MESSAGE_CODE, "Directory %s does not exist" % os.path.dirname(os.path.abspath(destination)))
             else:
-                self.logger_model.info("viewer:info", "Writing %s" % destination)
+                self.logger_model.info(INFO_MESSAGE_CODE, "Writing %s" % destination)
                 with open(destination, "wb") as fout:
                     writer = XHTMLSerializer(fout)
                     writer.serialize(self.files[0].xmlDocument)
                 if self.filingDocuments:
                     filename = os.path.basename(self.filingDocuments)
-                    self.logger_model.info("viewer:info", "Writing %s" % filename)
+                    self.logger_model.info(INFO_MESSAGE_CODE, "Writing %s" % filename)
                     shutil.copy2(self.filingDocuments, os.path.join(os.path.dirname(destination), filename))
                 if copyScriptPath is not None:
                     outDirectory = os.path.dirname(os.path.join(os.getcwd(), destination))
@@ -621,5 +621,5 @@ class iXBRLViewer:
     def _copyScript(self, directory: str, scriptPath: str):
         scriptSrc = os.path.join(directory, scriptPath)
         scriptDest = os.path.join(directory, os.path.basename(scriptPath))
-        self.logger_model.info("viewer:info", "Copying script from %s to %s" % (scriptSrc, scriptDest))
+        self.logger_model.info(INFO_MESSAGE_CODE, "Copying script from %s to %s" % (scriptSrc, scriptDest))
         shutil.copy2(scriptSrc, scriptDest)

--- a/iXBRLViewerPlugin/ui.py
+++ b/iXBRLViewerPlugin/ui.py
@@ -8,9 +8,9 @@ except ImportError:
 
 import os
 
-from .constants import CONFIG_FEATURE_PREFIX, CONFIG_FILE_DIRECTORY, CONFIG_LAUNCH_ON_LOAD, \
-    CONFIG_OUTPUT_FILE, CONFIG_SCRIPT_URL, CONFIG_ZIP_OUTPUT, DEFAULT_LAUNCH_ON_LOAD, \
-    GUI_FEATURE_CONFIGS
+from .constants import CONFIG_COPY_SCRIPT, CONFIG_FEATURE_PREFIX, CONFIG_FILE_DIRECTORY, \
+    CONFIG_LAUNCH_ON_LOAD, CONFIG_OUTPUT_FILE, CONFIG_SCRIPT_URL, CONFIG_ZIP_OUTPUT, \
+    DEFAULT_COPY_SCRIPT, DEFAULT_LAUNCH_ON_LOAD, GUI_FEATURE_CONFIGS
 
 UNSET_SCRIPT_URL = ''
 
@@ -30,6 +30,8 @@ class BaseViewerDialog(Toplevel):
             self._features[featureConfig.key] = featureVar
         self._scriptUrl = StringVar()
         self._scriptUrl.set(self.cntlr.config.setdefault(CONFIG_SCRIPT_URL, UNSET_SCRIPT_URL))
+        self._copyScript = BooleanVar()
+        self._copyScript.set(self.cntlr.config.setdefault(CONFIG_COPY_SCRIPT, DEFAULT_COPY_SCRIPT))
 
     def addButtons(self, frame: Frame, x: int, y: int) -> int:
         """
@@ -61,6 +63,12 @@ class BaseViewerDialog(Toplevel):
         scriptUrlEntry = Entry(frame, textvariable=self._scriptUrl, width=80)
         scriptUrlLabel.grid(row=y, column=0, sticky=W, pady=3, padx=3)
         scriptUrlEntry.grid(row=y, column=1, columnspan=2, sticky=EW, pady=3, padx=3)
+
+        y += 1
+        copyScriptCheckbutton = Checkbutton(frame, text="Copy Script", variable=self._copyScript, onvalue=True, offvalue=False)
+        copyScriptLabel = Label(frame, text="Copy the iXBRL Viewer script into the output directory.")
+        copyScriptCheckbutton.grid(row=y, column=0, pady=3, padx=3, sticky=W)
+        copyScriptLabel.grid(row=y, column=1, columnspan=3, pady=3, padx=3, sticky=W)
 
         y += 1
         featuresLabel = Label(frame, text="Generate with optional features:")
@@ -129,6 +137,9 @@ class BaseViewerDialog(Toplevel):
         self.protocol("WM_DELETE_WINDOW", self.close)
         self.grab_set()
         self.wait_window(self)
+
+    def copyScript(self):
+        return self._copyScript.get()
 
     def features(self):
         # Return list of feature keys with corresponding BooleanVar is set to True
@@ -238,6 +249,7 @@ class SettingsDialog(BaseViewerDialog):
         """
         self.cntlr.config[CONFIG_LAUNCH_ON_LOAD] = self._launchOnLoad.get()
         self.cntlr.config[CONFIG_SCRIPT_URL] = self._scriptUrl.get()
+        self.cntlr.config[CONFIG_COPY_SCRIPT] = self._copyScript.get()
         for key, var in self._features.items():
             self.cntlr.config[f'{CONFIG_FEATURE_PREFIX}{key}'] = var.get()
         self.cntlr.saveConfig()
@@ -249,5 +261,6 @@ class SettingsDialog(BaseViewerDialog):
         """
         self._launchOnLoad.set(DEFAULT_LAUNCH_ON_LOAD)
         self._scriptUrl.set(UNSET_SCRIPT_URL)
+        self._copyScript.set(DEFAULT_COPY_SCRIPT)
         for featureConfig in GUI_FEATURE_CONFIGS:
             self._features[featureConfig.key].set(featureConfig.guiDefault)

--- a/iXBRLViewerPlugin/xhtmlserialize.py
+++ b/iXBRLViewerPlugin/xhtmlserialize.py
@@ -53,7 +53,7 @@ class XHTMLSerializer:
         elif node.nsmap.get(node.prefix, None) == qname.namespace:
             prefix = node.prefix
         else:
-            prefix = next(iter(sorted((p for p, ns in nsmap.items() if ns == qname.namespace), key = self.prefix_sort)))
+            prefix = next(iter(sorted((p for p, ns in node.nsmap.items() if ns == qname.namespace), key = self.prefix_sort)))
         if prefix is None:
             return qname.localname
         return "%s:%s" % (prefix, qname.localname)

--- a/tests/puppeteer/tools/generate.sh
+++ b/tests/puppeteer/tools/generate.sh
@@ -10,6 +10,6 @@ for file in "$testFilingDir"/*.zip; do
     echo "Generating ixbrl-viewer for: $file"
     outputFilename=$(basename -- "$file")
     viewerName=${outputFilename%.zip}.htm
-    arelleCmdLine --plugins ixbrl-viewer -f $file --save-viewer $genDir/$viewerName --viewer-url ../../../../iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js
+    arelleCmdLine --plugins ixbrl-viewer -f $file --save-viewer $genDir/$viewerName --viewer-url ../../../../iXBRLViewerPlugin/viewer/dist/ixbrlviewer.js --viewer-no-copy-script
 done
 echo "iXBRL-Viewer Generation Complete"


### PR DESCRIPTION
#### Reason for change
Resolves #617 

#### Description of change
* Download and copy script into output directory if it's an http URL.
* Log an error and abort generation if script is to a file that doesn't exist or can't be downloaded.
* Add new `--viewer-no-copy-script` (also available in the GUI) option to skip copying or validating `--viewer-url` and trust the user to provide a valid script location.
* Don't open local viewer if generation failed.
* Include standard message codes on all Arelle logs.
* Fix a variable typo.

#### Steps to Test
* Test valid and invalid script URLs from both the GUI and CLI with and without the copy script option.

**review**:
@Arelle/arelle
@paulwarren-wk
