### PR TITLE
Move calculations mode option to options menu

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -1,14 +1,14 @@
 {
   "calculation": {
     "calculated-total": "Calculated",
-    "calculations11": "Calculations v1.1",
     "concept": "Concept",
     "consistent-duplicate-facts-present": "{{nfacts}} consistent duplicate facts present",
     "inconsistent-duplicate-facts-present": "{{nfacts}} inconsistent duplicate facts present",
     "maximum": "Maximum",
     "mininum": "Minimum",
     "reported-total": "Reported",
-    "reported-value": "Reported value"
+    "reported-value": "Reported value",
+    "useCalculations11": "Use Calculations v1.1"
   },
   "common": {
     "accuracyInfinite": "Infinite precision",

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -1,14 +1,14 @@
 {
   "calculation": {
     "calculated-total": "",
-    "calculations11": "",
     "concept": "",
     "consistent-duplicate-facts-present": "",
     "inconsistent-duplicate-facts-present": "",
     "maximum": "",
     "mininum": "",
     "reported-total": "",
-    "reported-value": ""
+    "reported-value": "",
+    "useCalculations11": ""
   },
   "common": {
     "accuracyInfinite": "Precisió infinita",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -210,6 +210,7 @@ export class Inspector {
             if (this._reportSet.filingDocuments()) {
                 this._optionsMenu.addDownloadButton("Download filing documents", this._reportSet.filingDocuments())
             }
+            this._optionsMenu.addCheckboxItem(i18next.t("calculation.useCalculations11"), (useCalc11) => this.setCalculationMode(useCalc11), "calculation-mode", "select-language", this._useCalc11);
         }
         this._iv.callPluginMethod("extendDisplayOptionsMenu", this._optionsMenu);
     }
@@ -218,7 +219,6 @@ export class Inspector {
         const iv = this._iv;
         this._toolbarMenu.reset();
         this._toolbarMenu.addCheckboxItem(i18next.t("toolbar.xbrlElements"), (checked) => this.highlightAllTags(checked), "highlight-tags", null, this._iv.options.highlightTagsOnStartup);
-        this._toolbarMenu.addCheckboxItem(i18next.t("calculation.calculations11"), (useCalc11) => this.setCalculationMode(useCalc11), "calculation-mode", "select-language", this._useCalc11);
         if (iv.isReviewModeEnabled()) {
             this._toolbarMenu.addCheckboxItem("Untagged Numbers", function (checked) {
                 const body = iv.viewer.contents().find("body");


### PR DESCRIPTION
#### Reason for change

The Calculation v1.1 mode switch was previously in the "highlight"  section of the top bar.  This seems wrong, as it doesn't really relate to highlighting, and it also seems unduly prominent for such an option.

#### Description of change

The Calculation v1.1 mode switch is relocated to the existing options menu:

![image](https://github.com/Arelle/ixbrl-viewer/assets/45077928/542c1c6d-7748-43bd-98b0-26d63512e92d)

#### Steps to Test

Open any report, and confirm that the Calculation v1.1 option is now on the options menu.

Changing this option will automatically update the fact inspector, although for most calculations this will have no visible impact.

Clicking the "details" link  on a calculation will open the calculation inspector, which will show the additional interval columns in Calculation v1.1 mode.

**review**:
@Arelle/arelle
@paulwarren-wk
