### PR TITLE
Display the target document of facts in inspector and search

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -381,10 +381,11 @@ class IXBRLViewerBuilder:
         with open(os.path.join(os.path.dirname(__file__),"stubviewer.html")) as fin:
             return etree.parse(fin)
 
-    def newTargetReport(self):
+    def newTargetReport(self, target):
         return {
             "concepts": {},
             "facts": {},
+            "target": target,
         }
 
     def addSourceReport(self):
@@ -425,7 +426,7 @@ class IXBRLViewerBuilder:
 
         for n, report in enumerate(self.reports):
             self.footnoteRelationshipSet = ModelRelationshipSet(report, "XBRL-footnotes")
-            self.currentTargetReport = self.newTargetReport()
+            self.currentTargetReport = self.newTargetReport(report.ixdsTarget)
             for f in report.facts:
                 self.addFact(report, f)
             self.currentTargetReport["rels"] = self.getRelationships(report)

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -426,7 +426,7 @@ class IXBRLViewerBuilder:
 
         for n, report in enumerate(self.reports):
             self.footnoteRelationshipSet = ModelRelationshipSet(report, "XBRL-footnotes")
-            self.currentTargetReport = self.newTargetReport(report.ixdsTarget)
+            self.currentTargetReport = self.newTargetReport(getattr(report, "ixdsTarget", None))
             for f in report.facts:
                 self.addFact(report, f)
             self.currentTargetReport["rels"] = self.getRelationships(report)

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -183,8 +183,11 @@ See COPYRIGHT.md for copyright information
           <p class="title" data-i18n="inspector.noFactSelected">No Fact Selected</p>
         </div>
         <div class="fact-selected-only">
-          <div class="hidden-fact-tag" data-i18n="inspector.hiddenFact">Hidden Fact</div>
-          <div class="html-hidden-fact-tag" data-i18n="inspector.concealedFact">Concealed Fact</div>
+          <div class="tags">
+            <div class="target-document"></div>
+            <div class="hidden-fact-tag" data-i18n="inspector.hiddenFact">Hidden Fact</div>
+            <div class="html-hidden-fact-tag" data-i18n="inspector.concealedFact">Concealed Fact</div>
+          </div>
           <div class="collapsible-section">
             <div class="fact-inspector collapsible-body">
             </div>

--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -404,4 +404,8 @@ export class Fact {
         }
         return this.decimals() > of.decimals();
     }
+
+    targetDocument() {
+        return this.report.targetDocument();
+    }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -314,7 +314,7 @@ export class Inspector {
             }
         }
         const tags = $("<div></div>").addClass("tags").appendTo(row);
-        if (f.targetDocument() !== undefined) {
+        if (f.targetDocument() !== null) {
             $('<div class="hidden"></div>')
                 .text(f.targetDocument())
                 .appendTo(tags);
@@ -1083,7 +1083,7 @@ export class Inspector {
                 }
 
                 const target = cf.targetDocument();
-                if (target !== undefined) {
+                if (target !== null) {
                     $('#inspector .target-document').text(target).show();
                 }
                 else {

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -313,15 +313,21 @@ export class Inspector {
                     .appendTo(row);
             }
         }
+        const tags = $("<div></div>").addClass("tags").appendTo(row);
+        if (f.targetDocument() !== undefined) {
+            $('<div class="hidden"></div>')
+                .text(f.targetDocument())
+                .appendTo(tags);
+        }
         if (f.isHidden()) {
             $('<div class="hidden"></div>')
                 .text(i18next.t("search.hiddenFact"))
-                .appendTo(row);
+                .appendTo(tags);
         }
         else if (f.isHTMLHidden()) {
             $('<div class="hidden"></div>')
                 .text(i18next.t("search.concealedFact"))
-                .appendTo(row);
+                .appendTo(tags);
         }
         return row;
     }
@@ -1074,6 +1080,14 @@ export class Inspector {
                 }
                 else if (cf.isHTMLHidden()) {
                     $('#inspector').addClass('html-hidden-fact');
+                }
+
+                const target = cf.targetDocument();
+                if (target !== undefined) {
+                    $('#inspector .target-document').text(target).show();
+                }
+                else {
+                    $('#inspector .target-document').hide();
                 }
 
             }

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -39,7 +39,7 @@ export class XBRLReport {
     }
 
     targetDocument() {
-        return this._reportData.target ?? undefined;
+        return this._reportData.target ?? null;
     }
 
     getChildRelationships(conceptName, arcrole) {

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -38,6 +38,10 @@ export class XBRLReport {
         return this.reportSet.factsForReport(this);
     }
 
+    targetDocument() {
+        return this._reportData.target ?? undefined;
+    }
+
     getChildRelationships(conceptName, arcrole) {
         const rels = {}
         const elrs = this._reportData.rels[arcrole] || {};

--- a/iXBRLViewerPlugin/viewer/src/less/block-list.less
+++ b/iXBRLViewerPlugin/viewer/src/less/block-list.less
@@ -12,6 +12,11 @@
     margin: 0.8rem 0;
   }
 
+  // Contents of .tags provide 0.2rem of non-collapsing margin
+  & > .tags {
+    margin: 0.6rem 0;
+  }
+
   &:hover {
     background-color: @background-selected;
   }

--- a/iXBRLViewerPlugin/viewer/src/less/components.less
+++ b/iXBRLViewerPlugin/viewer/src/less/components.less
@@ -1,13 +1,15 @@
 // See COPYRIGHT.md for copyright information
 
 .tag {
-  display: table;
+  display: inline-block;
   text-transform: uppercase;
   font-weight: bold;
   background-color: @background-tag;
   padding: 0.15em 0.5em;
   color: #fff;
   border-radius: 0.3em;
+  margin: 0.2rem 0.3rem 0.2rem 0;
+  white-space: nowrap;
 }
 
 .clickable {

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -676,13 +676,19 @@
       top: 1px;
     }
 
-    .hidden-fact-tag,
-    .html-hidden-fact-tag {
-      .tag();
-
+    .inspector-body-fact .tags {
       position: absolute;
       top: 1.5rem;
       right: 0.9rem;
+    }
+
+    .target-document {
+      .tag();
+    }
+
+    .hidden-fact-tag,
+    .html-hidden-fact-tag {
+      .tag();
 
       &.html-hidden-fact-tag {
         background-color: #c63018;

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -328,7 +328,8 @@ class TestIXBRLViewer:
                 "filepath":'a.html',
                 "objectIndex":0,
                 "type":Type.INLINEXBRL,
-            }
+            },
+            ixdsTarget=None,
         )
 
         self.modelDocumentInlineSet = Mock(
@@ -353,7 +354,8 @@ class TestIXBRLViewer:
                 ): [],
             },
             filepath=self.modelDocument.filepath,
-            type=Type.INLINEXBRLDOCUMENTSET
+            type=Type.INLINEXBRLDOCUMENTSET,
+            ixdsTarget=None,
         )
 
         error1 = logging.LogRecord("arelle", logging.ERROR, "", 0, "Error message", {}, None)    
@@ -389,6 +391,7 @@ class TestIXBRLViewer:
             info=info_effect,
             modelDocument=self.modelDocument,
             modelManager=self.modelManager,
+            ixdsTarget=None,
             urlDocs=dict((
                 urlDocEntry('/filesystem/local-inline.htm', Type.INLINEXBRL),
                 urlDocEntry('https://example.com/remote-inline.htm', Type.INLINEXBRL),
@@ -419,6 +422,7 @@ class TestIXBRLViewer:
             info=info_effect,
             modelDocument=self.modelDocument,
             modelManager=self.modelManager,
+            ixdsTarget=None,
             urlDocs={}
         )
         self.modelXbrlDocSet = Mock(
@@ -430,6 +434,7 @@ class TestIXBRLViewer:
             info=info_effect,
             modelDocument=self.modelDocumentInlineSet,
             modelManager=self.modelManager,
+            ixdsTarget=None,
             urlDocs={}
         )
 
@@ -450,7 +455,7 @@ class TestIXBRLViewer:
     @patch('arelle.XbrlConst.conceptReference', 'http://www.xbrl.org/2003/arcrole/concept-reference')
     def test_addConcept_simple_case(self):
         builder = IXBRLViewerBuilder([self.modelXbrl_1])
-        builder.currentTargetReport = builder.newTargetReport()
+        builder.currentTargetReport = builder.newTargetReport(None)
         builder.addSourceReport()["targetReports"].append(builder.currentTargetReport)
         builder.addConcept(self.modelXbrl_1, self.cash_concept)
         assert builder.taxonomyData["sourceReports"][0]["targetReports"][0].get('concepts').get('us-gaap:Cash')
@@ -467,7 +472,7 @@ class TestIXBRLViewer:
     @patch('arelle.XbrlConst.summationItem', 'http://www.xbrl.org/2003/arcrole/summation-item')
     def test_getRelationships_returns_a_rel(self):
         builder = IXBRLViewerBuilder([self.modelXbrl_1])
-        builder.currentTargetReport = builder.newTargetReport()
+        builder.currentTargetReport = builder.newTargetReport(None)
         result = builder.getRelationships(self.modelXbrl_1)
         roleMap = builder.roleMap
         siPrefix = roleMap.getPrefix('http://www.xbrl.org/2003/arcrole/summation-item')
@@ -479,7 +484,7 @@ class TestIXBRLViewer:
         """
         elr = "http://example.com/unknownELR"
         builder = IXBRLViewerBuilder([self.modelXbrl_1])
-        builder.currentTargetReport = builder.newTargetReport()
+        builder.currentTargetReport = builder.newTargetReport(None)
         builder.addELR(self.modelXbrl_1, elr)
         elrPrefix = builder.roleMap.getPrefix(elr)
         assert builder.currentTargetReport.get('roleDefs').get(elrPrefix) is None
@@ -490,7 +495,7 @@ class TestIXBRLViewer:
         """
         elr = "ELR"
         builder = IXBRLViewerBuilder([self.modelXbrl_1])
-        builder.currentTargetReport = builder.newTargetReport()
+        builder.currentTargetReport = builder.newTargetReport(None)
         builder.addELR(self.modelXbrl_1, elr)
         elrPrefix = builder.roleMap.getPrefix(elr)
         assert builder.currentTargetReport.get('roleDefs').get(elrPrefix).get("en") == "ELR Label"


### PR DESCRIPTION
#### Reason for change

The viewer will load facts from multiple target documents, but does not show which facts come from with target document.

#### Description of change

Facts from a non-default target document are now tagged as such in search results and the fact inspector:

![image](https://github.com/Arelle/ixbrl-viewer/assets/45077928/c913467d-657a-48b7-afe1-6855ec48cea3)

Search:

![image](https://github.com/Arelle/ixbrl-viewer/assets/45077928/a2854366-edef-4236-bb34-4fad6e950ab6)

Target document information was not previously included in the report data, so new JS running on old reports will not show target document information.

#### Steps to Test

Load a document with at least one non-default target document, and check that the target document is indicated in search results and the fact inspector.

**review**:
@Arelle/arelle
@paulwarren-wk
