### PR TITLE
Target document search filter

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -116,6 +116,18 @@ See COPYRIGHT.md for copyright information
             </div>
           </div>
 
+          <div id="search-filter-target-document" class="collapsible-section collapsible-only collapsed">
+            <h3 class="collapsible-header">
+              <span data-i18n="inspector.targetDocument">Target Document</span>
+              <span class="collapsible-subheader"></span>
+            </h3>
+            <div class="collapsible-body target-document" style="display: none;">
+              <span class="reset-multiselect"></span>
+              <select multiple>
+              </select>
+            </div>
+          </div>
+
           <div id="search-filter-units" class="collapsible-section collapsible-only collapsed">
             <h3 class="collapsible-header">
               <span data-i18n="inspector.units">Units</span>
@@ -184,7 +196,7 @@ See COPYRIGHT.md for copyright information
         </div>
         <div class="fact-selected-only">
           <div class="tags">
-            <div class="target-document"></div>
+            <div class="target-document-tag"></div>
             <div class="hidden-fact-tag" data-i18n="inspector.hiddenFact">Hidden Fact</div>
             <div class="html-hidden-fact-tag" data-i18n="inspector.concealedFact">Concealed Fact</div>
           </div>

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -134,6 +134,7 @@
   },
   "search": {
     "concealedFact": "Concealed fact",
+    "default": "default",
     "hiddenFact": "Hidden fact",
     "noMatchFound": "No match found",
     "selected": "selected",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -384,11 +384,17 @@ export class Inspector {
                 .text(`${prefix} (${this._reportSet.prefixMap()[prefix]})`)
                 .appendTo('#search-filter-namespaces select');
         }
-        for (const targetDocument of this._reportSet.getTargetDocuments()) {
-            $("<option>")
-                .attr("value", targetDocument ?? ':default')
-                .text(targetDocument ?? `<${i18next.t("search.default")}>`)
-                .appendTo('#search-filter-target-document select');
+        const targetDocuments = Array.from(this._reportSet.getTargetDocuments());
+        if (targetDocuments.length == 1 && targetDocuments[0] == null) {
+            $('#search-filter-target-document').hide();
+        }
+        else {
+            for (const targetDocument of targetDocuments) {
+                $("<option>")
+                    .attr("value", targetDocument ?? ':default')
+                    .text(targetDocument ?? `<${i18next.t("search.default")}>`)
+                    .appendTo('#search-filter-target-document select');
+            }
         }
         for (const unit of this._reportSet.getUsedUnits()) {
             $("<option>")

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -359,6 +359,7 @@ export class Inspector {
         spec.factValueFilter = $('#search-filter-fact-value').val();
         spec.calculationsFilter = $('#search-filter-calculations select').val();
         spec.dimensionTypeFilter = $('#search-filter-dimension-type select').val();
+        spec.targetDocumentFilter = $('#search-filter-target-document select').val();
         return spec;
     }
 
@@ -382,6 +383,12 @@ export class Inspector {
                 .attr("value", prefix)
                 .text(`${prefix} (${this._reportSet.prefixMap()[prefix]})`)
                 .appendTo('#search-filter-namespaces select');
+        }
+        for (const targetDocument of this._reportSet.getTargetDocuments()) {
+            $("<option>")
+                .attr("value", targetDocument ?? ':default')
+                .text(targetDocument ?? `<${i18next.t("search.default")}>`)
+                .appendTo('#search-filter-target-document select');
         }
         for (const unit of this._reportSet.getUsedUnits()) {
             $("<option>")
@@ -422,6 +429,7 @@ export class Inspector {
         $("#search-hidden-fact-filter").prop("checked", true);
         $("#search-visible-fact-filter").prop("checked", true);
         $("#search-filter-namespaces select option:selected").prop("selected", false);
+        $("#search-filter-target-document select option:selected").prop("selected", false);
         $("#search-filter-units select option:selected").prop("selected", false);
         $("#search-filter-scales select option:selected").prop("selected", false);
         this.search();
@@ -461,6 +469,7 @@ export class Inspector {
         this.updateMultiSelectSubheader('search-filter-scales');
         this.updateMultiSelectSubheader('search-filter-units');
         this.updateMultiSelectSubheader('search-filter-namespaces');
+        this.updateMultiSelectSubheader('search-filter-target-document');
         this.updateMultiSelectSubheader('search-filter-dimension-type');
         this.updateMultiSelectSubheader('search-filter-calculations');
         this.updateMultiSelectSubheader('search-filter-period');
@@ -1084,10 +1093,10 @@ export class Inspector {
 
                 const target = cf.targetDocument();
                 if (target !== null) {
-                    $('#inspector .target-document').text(target).show();
+                    $('#inspector .target-document-tag').text(target).show();
                 }
                 else {
-                    $('#inspector .target-document').hide();
+                    $('#inspector .target-document-tag').hide();
                 }
 
             }

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.js
@@ -118,6 +118,15 @@ export class ReportSet {
         return this._usedPrefixes;
     }
 
+    getTargetDocuments() {
+        if (this._targetDocuments === undefined) {
+            this._targetDocuments = new Set(Object.values(this._items)
+                    .filter(f => f instanceof Fact)
+                    .map(f => f.targetDocument()));
+        }
+        return this._targetDocuments;
+    }
+
     /**
      * Returns a set of OIM format unit strings used by facts on this report. Lazy-loaded.
      * @return {Set[String]} Set of OIM format unit strings

--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -154,6 +154,13 @@ export class ReportSearch {
         );
     }
 
+    targetDocumentFilter(s, item) {
+        return (
+            s.targetDocumentFilter.length === 0 ||
+            s.targetDocumentFilter.some(t => (item.targetDocument() ?? ':default') === t)
+        );
+    }
+
     search(s) {
         if (!this.ready) {
             return;
@@ -172,6 +179,7 @@ export class ReportSearch {
             this.namespacesFilter,
             this.unitsFilter,
             this.scalesFilter,
+            this.targetDocumentFilter
         ];
 
         rr.forEach((r,_) => {

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -15,6 +15,7 @@ const testReportData = {
     "rels": {},
 };
 
+
 function getReportSearch(report) {
     const reportSearch = new ReportSearch(report);
     const searchIndex = reportSearch.buildSearchIndex(() => {});
@@ -52,24 +53,46 @@ function createDimensionalizedFact(id, concept, options=null, dimensions= {}) {
 }
 
 
-function testReport(ixData, testData) {
-    // Deep copy of standing data
-    const data = {
-        ...JSON.parse(JSON.stringify(testReportData)),
-        ...testData
-    }
-    Object.keys(data['facts']).forEach(id => {
-        if (!(id in ixData)) {
-            ixData[id] = {};
-        }
-    })
-    ixData = Object.fromEntries(
-        Object.entries(ixData).map(([id, v]) => [viewerUniqueId(0,id), v])
-    );
-    const report = new ReportSet(data);
-    report.setIXNodeMap(ixData);
-    return report;
+// Returns a report set with a single report
+function testReport(testData, sourceIXData) {
+    return testReportSet([ {data: testData, ixData: sourceIXData ?? {} } ])
 }
+
+function mergeDicts(a, b) {
+    a ??= {};
+    b ??= {};
+    return { ...a, ...b };
+}
+
+function testReportSet(reports) {
+    const targetReports = [];
+    const reportSetData = {
+        "sourceReports": [{ "targetReports": targetReports }],
+    };
+
+    const ixData = {};
+    for (const [n, report] of reports.entries()) {
+        const targetReport = {};
+        for (const key of ["languages", "prefixes", "roles"]) {
+            reportSetData[key] = mergeDicts(reportSetData[key], report.data[key]);
+        }
+        for (const key of ["concepts", "facts", "roleDefs", "rels"]) {
+            targetReport[key] = report.data[key] ?? {};
+        }
+        targetReport["target"] = report.data["target"] ?? null;
+
+        for (const id of Object.keys(targetReport.facts)) {
+            if (!(id in ixData)) {
+                ixData[viewerUniqueId(n,id)] = report.ixData?.[id] ?? {};
+            }
+        } 
+        targetReports.push(targetReport);
+    }
+    const reportSet = new ReportSet(reportSetData);
+    reportSet.setIXNodeMap(ixData);
+    return reportSet;
+}
+
 
 function testSearchSpec(searchString='') {
     const spec = {};
@@ -84,6 +107,7 @@ function testSearchSpec(searchString='') {
     spec.dimensionTypeFilter = [];
     spec.factValueFilter = '*';
     spec.calculationsFilter = [];
+    spec.targetDocumentFilter = [];
     return spec;
 }
 
@@ -91,7 +115,6 @@ describe("Search fact value filter", () => {
     const cashConcept = 'us-gaap:Cash';
     const cashUnit = 'iso4217:USD';
     const report = testReport(
-            {'positive': {}, 'negative': {}, 'zero': {}, 'text': {}, 'undefined': {}},
             {
                 'concepts': {
                     ...createSimpleConcept(cashConcept, 'Cash')
@@ -144,7 +167,6 @@ describe("Search fact value filter", () => {
 
 describe("Search calculation filter", () => {
     const report = testReport(
-            {'summation': {}, 'item1': {}, 'item2': {}, 'other': {}},
             {
                 "concepts": {
                     ...createSimpleConcept("test:Summation", "Summation"),
@@ -200,7 +222,6 @@ describe("Search calculation filter", () => {
         expect(results).toEqual(['item1', 'item2', 'summation']);
     });
     const emptyReport = testReport(
-            {'fact': {}},
             {
                 "concepts": {
                     ...createSimpleConcept("test:Concept", "Concept"),
@@ -222,7 +243,6 @@ describe("Search calculation filter", () => {
 
 describe("Search namespaces filter", () => {
     const report = testReport(
-            {'itemA1': {}, 'itemA2': {}, 'itemB1': {}, 'itemC1': {}},
             {
                 "concepts": {
                     ...createSimpleConcept("a:ItemA1", "ItemA1"),
@@ -297,7 +317,6 @@ describe("Search units filter", () => {
 
     beforeAll(() => {
         report = testReport(
-                {'itemA': {}, 'itemAB': {}, 'itemB': {}, 'itemBA': {}},
                 {
                     "concepts": {
                         ...createSimpleConcept("a:ItemA", "ItemA"),
@@ -358,7 +377,6 @@ describe("Search units filter", () => {
 
 describe("Search dimension type filter", () => {
     const report = testReport(
-            {},
             {
                 "concepts": {
                     ...createSimpleConcept("test:Concept", "Concept"),
@@ -412,7 +430,6 @@ describe("Search dimension type filter", () => {
     });
 
     const emptyReport = testReport(
-            {'fact': {}},
             {
                 "concepts": {
                     ...createSimpleConcept("test:Concept", "Concept"),
@@ -436,18 +453,6 @@ describe("Search scales filter", () => {
     const cashUnit = 'test:USD';
     const period = '2018-01-01/2019-01-01';
     const report = testReport(
-            {
-                "item-3": { "scale": -3 },
-                "item-2": { "scale": -2 },
-                "item-1": { "scale": -1 },
-                "item0": { },
-                "item1": { "scale": 1 },
-                "item2": { "scale": 2 },
-                "item3": { "scale": 3 },
-                "item6": { "scale": 6 },
-                "item9": { "scale": 9 },
-                "item12": { "scale": 12 },
-            },
             {
                 "concepts": {
                     ...createSimpleConcept("a:Item-3"),
@@ -475,6 +480,18 @@ describe("Search scales filter", () => {
                     ...createNumericFact("item12", "a:Item12", cashUnit, period, 1000000000000),
                     ...createSimpleFact("itemOther", "a:Other"),
                 },
+            },
+            {
+                "item-3": { "scale": -3 },
+                "item-2": { "scale": -2 },
+                "item-1": { "scale": -1 },
+                "item0": { },
+                "item1": { "scale": 1 },
+                "item2": { "scale": 2 },
+                "item3": { "scale": 3 },
+                "item6": { "scale": 6 },
+                "item9": { "scale": 9 },
+                "item12": { "scale": 12 },
             }
     )
     const reportSearch = getReportSearch(report);
@@ -499,4 +516,103 @@ describe("Search scales filter", () => {
         const results = reportSearch.search(spec).map(r => r.fact.localId()).sort();
         expect(results).toEqual(['item-2', 'item2']);
     });
+});
+
+describe("Search target document filter", () => {
+    const cashUnit = 'test:USD';
+    const period = '2018-01-01/2019-01-01';
+    const singleReport = testReport(
+            {
+                "concepts": {
+                    ...createSimpleConcept("a:Item0"),
+                    ...createSimpleConcept("a:Item1"),
+                    ...createSimpleConcept("a:Item2"),
+                },
+                "facts": {
+                    ...createNumericFact("item0", "a:Item0", cashUnit, period, 1),
+                    ...createNumericFact("item1", "a:Item1", cashUnit, period, 10),
+                    ...createNumericFact("item2", "a:Item2", cashUnit, period, 100),
+                },
+            },
+    );
+    const singleReportSearch = getReportSearch(singleReport);
+
+    test("Target document filter works without selection", () => {
+        const spec = testSearchSpec();
+        spec.targetDocumentFilter = [];
+        const results = singleReportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['item0', 'item1', 'item2' ]);
+    });
+
+    test("Target document filter with default document", () => {
+        const spec = testSearchSpec();
+        spec.targetDocumentFilter = [ ':default' ];
+        const results = singleReportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['item0', 'item1', 'item2' ]);
+    });
+
+    const multiReport = testReportSet([ 
+        {
+            data: {
+                target: null,
+                "concepts": {
+                    ...createSimpleConcept("a:Item0"),
+                    ...createSimpleConcept("a:Item1"),
+                    ...createSimpleConcept("a:Item2"),
+                },
+                "facts": {
+                    ...createNumericFact("item0", "a:Item0", cashUnit, period, 1),
+                    ...createNumericFact("item1", "a:Item1", cashUnit, period, 10),
+                    ...createNumericFact("item2", "a:Item2", cashUnit, period, 100),
+                },
+            },
+        },
+        {
+            data: {
+                target: "ABC",
+                "concepts": {
+                    ...createSimpleConcept("a:Item3"),
+                    ...createSimpleConcept("a:Item4"),
+                    ...createSimpleConcept("a:Item5"),
+                },
+                "facts": {
+                    ...createNumericFact("item3", "a:Item3", cashUnit, period, 1),
+                    ...createNumericFact("item4", "a:Item4", cashUnit, period, 10),
+                    ...createNumericFact("item5", "a:Item5", cashUnit, period, 100),
+                },
+            },
+        }
+
+    ]);
+
+    const multiReportSearch = getReportSearch(multiReport);
+
+    test("Target document filter works without selection (multiple targets)", () => {
+        const spec = testSearchSpec();
+        spec.targetDocumentFilter = [];
+        const results = multiReportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['item0', 'item1', 'item2', 'item3', 'item4', 'item5' ]);
+    });
+
+    test("Target document filter works with default (multiple targets)", () => {
+        const spec = testSearchSpec();
+        spec.targetDocumentFilter = [ ':default' ];
+        const results = multiReportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['item0', 'item1', 'item2']);
+    });
+
+    test("Target document filter works with second target (multiple targets)", () => {
+        const spec = testSearchSpec();
+        spec.targetDocumentFilter = [ 'ABC' ];
+        const results = multiReportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['item3', 'item4', 'item5']);
+    });
+
+    test("Target document filter works with multi-select (multiple targets)", () => {
+        const spec = testSearchSpec();
+        spec.targetDocumentFilter = [ ':default', 'ABC' ];
+        const results = multiReportSearch.search(spec).map(r => r.fact.localId()).sort();
+        expect(results).toEqual(['item0', 'item1', 'item2', 'item3', 'item4', 'item5' ]);
+    });
+
 });

--- a/iXBRLViewerPlugin/viewer/src/js/search.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.test.js
@@ -28,6 +28,7 @@ function createDimensionConcept(name, label, isExplicit= true) {
     c[name]["d"] = isExplicit ? "e": "t";
     return c;
 }
+
 function createSimpleConcept(name, label=null) {
     return {
         [name]: {
@@ -51,7 +52,6 @@ function createDimensionalizedFact(id, concept, options=null, dimensions= {}) {
     }
     return fact;
 }
-
 
 // Returns a report set with a single report
 function testReport(testData, sourceIXData) {
@@ -92,7 +92,6 @@ function testReportSet(reports) {
     reportSet.setIXNodeMap(ixData);
     return reportSet;
 }
-
 
 function testSearchSpec(searchString='') {
     const spec = {};
@@ -305,7 +304,6 @@ describe("Search namespaces filter", () => {
 });
 
 describe("Search units filter", () => {
-
     const cashUnit = 'test:USD';
     const shareUnit = 'test:share';
     const cashShareUnit = `${cashUnit} / ${shareUnit}`

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -682,7 +682,7 @@
       right: 0.9rem;
     }
 
-    .target-document {
+    .target-document-tag {
       .tag();
     }
 


### PR DESCRIPTION
#### Reason for change

Allows users to limit searches to specific target documents in multi-target documents.

#### Description of change

Adds a "target documents" filter to the search filters:  

![image](https://github.com/Arelle/ixbrl-viewer/assets/45077928/cecf6cff-cf8a-4607-93f7-5f4b65323bb9)

This is only shown if there is at least one non-default target document used in the report.

#### Steps to Test

Open a report with a single, default document.  Click on search, then the filters icon, confirm that "Target Documents" filter is not shown.

Open a report with multiple target documents (e.g. Danish ESEF filings).  Confirm that "Target Documents" filter is now shown, and that the relevant facts are shown in the results when selected.

**review**:
@Arelle/arelle
@paulwarren-wk
