### PR TITLE
Switch to using Intl.DisplayNames

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -14,7 +14,6 @@ from collections import defaultdict
 from copy import deepcopy
 from pathlib import Path
 
-import pycountry
 from arelle import XbrlConst
 from arelle.ModelDocument import Type
 from arelle.ModelRelationshipSet import ModelRelationshipSet

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -92,7 +92,6 @@ class IXBRLViewerBuilder:
         self.taxonomyData = {
             "sourceReports": [],
             "features": [],
-            "languages": {},
         }
         self.basenameSuffix = basenameSuffix
         self.currentTargetReport = None
@@ -132,23 +131,6 @@ class IXBRLViewerBuilder:
         """
         return s.replace("<","\\u003C").replace(">","\\u003E").replace("&","\\u0026")
 
-    def makeLanguageName(self, langCode):
-        code = re.sub("-.*","",langCode)
-        try:
-            language = pycountry.languages.lookup(code)
-            match = re.match(r'^[^-]+-(.*)$',langCode)
-            name = language.name
-            if match is not None:
-                name = "%s (%s)" % (name, match.group(1).upper())
-        except LookupError:
-            name = langCode
-
-        return name
-
-    def addLanguage(self, langCode):
-        if langCode not in self.taxonomyData["languages"]:
-            self.taxonomyData["languages"][langCode] = self.makeLanguageName(langCode)
-
     def addELR(self, report: ModelXbrl, elr):
         prefix = self.roleMap.getPrefix(elr)
         if self.currentTargetReport.setdefault("roleDefs",{}).get(prefix, None) is None:
@@ -170,7 +152,6 @@ class IXBRLViewerBuilder:
             for lr in labels:
                 l = lr.toModelObject
                 conceptData["labels"].setdefault(self.roleMap.getPrefix(l.role),{})[l.xmlLang.lower()] = l.text;
-                self.addLanguage(l.xmlLang.lower());
 
             refData = []
             for _refRel in concept.modelXbrl.relationshipSet(XbrlConst.conceptReference).fromModelObject(concept):

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -205,7 +205,16 @@ export class Inspector {
         this._optionsMenu.reset();
         if (this._reportSet) {
             const dl = this.selectDefaultLanguage();
-            this._optionsMenu.addCheckboxGroup(this._reportSet.availableLanguages(), this._reportSet.languageNames(), dl, (lang) => { this.setLanguage(lang); this.update() }, "select-language");
+            const langs = this._reportSet.availableLanguages();
+            const langNames = new Intl.DisplayNames(this.preferredLanguages(), { "type": "language" });
+
+            this._optionsMenu.addCheckboxGroup(
+                langs,
+                Object.fromEntries(langs.map((l) => [l, langNames.of(l)])),
+                dl,
+                (lang) => { this.setLanguage(lang); this.update() },
+                "select-language"
+            );
             this.setLanguage(dl);
             if (this._reportSet.filingDocuments()) {
                 this._optionsMenu.addDownloadButton("Download filing documents", this._reportSet.filingDocuments())

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -74,13 +74,6 @@ describe("Language options", () => {
         expect(al).toHaveLength(6);
         expect(al).toEqual(expect.arrayContaining(["en", "en-us", "en-gb", "fr", "de", "es"]));
     });
-
-    test("Names for available languages", () => {
-        const ln = testReportSet.languageNames();
-        expect(Object.keys(ln)).toHaveLength(2);
-        expect(ln['en']).toBe("English");
-        expect(ln['en-us']).toBe("English (US)");
-    });
 });
 
 describe("Fetching facts", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.js
@@ -178,10 +178,6 @@ export class ReportSet {
         return usedScalesMap;
     }
 
-    languageNames() {
-        return this._data.languages;
-    }
-
     roleMap() {
         return this._data.roles;
     }

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.test.js
@@ -185,14 +185,6 @@ describe("Multi report - Language options", () => {
         expect(al).toHaveLength(3);
         expect(al).toEqual(expect.arrayContaining(["en", "en-us", "en-gb"]));
     });
-
-    test("Names for languages", () => {
-        const ln = testReportSet.languageNames();
-        expect(Object.keys(ln)).toHaveLength(3);
-        expect(ln['en']).toBe("English");
-        expect(ln['en-us']).toBe("English (US)");
-        expect(ln['fr']).toBe("French");
-    });
 });
 
 describe("Multi report - Fetching facts", () => {
@@ -293,14 +285,6 @@ describe("Single report - Language options", () => {
         const al = testReportSet.availableLanguages();
         expect(al).toHaveLength(2);
         expect(al).toEqual(expect.arrayContaining(["en", "en-us"]));
-    });
-
-    test("Names for languages", () => {
-        const ln = testReportSet.languageNames();
-        expect(Object.keys(ln)).toHaveLength(3);
-        expect(ln['en']).toBe("English");
-        expect(ln['en-us']).toBe("English (US)");
-        expect(ln['fr']).toBe("French");
     });
 });
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    'lxml>=4,<6',
-    'pycountry>=22,<24'
+    'lxml>=4,<6'
 ]
 [project.optional-dependencies]
 arelle = [


### PR DESCRIPTION
Use built-in JS support for multi-lingual labels for languages, rather than including them in the viewer JSON.

Fixes #573

#### Reason for change

We currently include names for languages as part of the viewer JSON and only include them in a single language.  This means that they're not translated as part of the i18n support.

Modern JS provides `Intl.DisplayNames` which can give us language labels in different languages.

#### Description of change

Get labels for languages using `Intl.DisplayNames`.

No longer include `languages` in the taxonomy data object.

New viewers will ignore the `languages` object if present.

#### Steps to Test

Open a viewer, check the list of languages shown on the settings menu.  They should be displayed in the language  of the current locale, but this can be overridden by specifying `?lang=XX` as a query param, where `XX` is a language code.  Where this is done, the language names should be translated.

**review**:
@Arelle/arelle
@paulwarren-wk
