### PR TITLE
Avoid interfering with layout of tables with absolutely positioned content

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/tableExport.js
+++ b/iXBRLViewerPlugin/viewer/src/js/tableExport.js
@@ -16,11 +16,26 @@ export class TableExport {
         $('table', iframe).each(function () {
             const table = $(this);
             if (table.find(".ixbrl-element").length > 0) {
-                table.css("position", "relative");
-                const exporter = new TableExport(table, reportSet);
-                $('<div class="ixbrl-table-handle"><span>Export table</span></div>')
-                    .appendTo(table)
-                    .click(() => exporter.exportTable());
+                const containsAbsolute = Array.from(this.querySelectorAll("*"))
+                    .reduce(
+                        (res, elt) => (res || getComputedStyle(elt).getPropertyValue('position') === 'absolute'),
+                        false
+                    );
+
+                // Don't add handles if the table contains absolutely
+                // positioned elements, as doing so will probably interfere
+                // with layout.
+                //
+                // Where a table has absolutely positioned content, it's quite
+                // likely that the table tag itself is positioned in a random
+                // place.
+                if (!containsAbsolute) {
+                    table.css("position", "relative");
+                    const exporter = new TableExport(table, reportSet);
+                    $('<div class="ixbrl-table-handle"><span>Export table</span></div>')
+                        .appendTo(table)
+                        .click(() => exporter.exportTable());
+                }
             }
         });
     }

--- a/samples/src/testdoc/testdoc.ixtmpl
+++ b/samples/src/testdoc/testdoc.ixtmpl
@@ -164,13 +164,18 @@ Profit Loss double tagged: {{ monetary eg:ProfitLoss[] }}{{ monetary eg:ProfitLo
         {{ period cur3mo "2018-09-01" "2018-12-31" }}
         {{ period prev3mo "2017-09-01" "2017-12-31" }}
 
+        <p>
+            This table contains some absolutely position content, so should not
+            have a table export handle.
+        </p>
+
         <table class="accounts">
             {{ column-aspects static [period=cur] [period=prev] [period=cur3mo] [period=prev3mo] }}
             {{ column-styles "" "figure" "figure" "figure" "figure" }}
             <thead>
                 <tr>
                     <th></th>
-                    <th>2018</th>
+                    <th style="position: relative"><div style="position: absolute">2018</div></th>
                     <th>2017</th>
                     <th>3 months to <br></br>31 Dec 2018</th>
                     <th>3 months to <br></br>31 Dec 2017</th>


### PR DESCRIPTION
Fixes #632

#### Reason for change

The viewer currently interferes with the layout of tables that contain absolutely positioned content.  The problematic situation is this:

```html
    <div class="page" style="position: absolute">
        <table>
            <tr>
                <td>
                    <div style="position: absolute">1,000</div>
                </td>
            </tr>
        </table>
    </div>
```

The viewer then adds `position: relative` to the `<table>` tag, which means that the absolutely position `<div>` is now positioned with respect to the wrong parent.

The viewer adds this class, because it is used to place the table export icon in the top left of the table.

#### Description of change

The viewer no longer adds an export handle if absolutely positioned content is found within the table.

It would obviously better to enable the export functionality, as the presence of the table tags means that the export should work (where previously it didn't on most ESEF filings), but it's not at all trivial, as the `<table>` tag is likely to be rendered is some random location.

#### Steps to Test

Check that the layout of the sample document on #632 is now correct when loaded in the viewer.


**review**:
@Arelle/arelle
@paulwarren-wk
