### PR TITLE
Show escaped values for non-textblock facts

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/fact.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.js
@@ -90,7 +90,7 @@ export class Fact {
         else if (this.isNil()) {
             v = "nil";
         }
-        else if (this.escaped()) {
+        else if (this.isTextBlock()) {
             const html = $("<div>").append($($.parseHTML(v, null, false)));
             /* Insert an extra space at the beginning and end of block elements to
              * preserve separation of sections of text. */

--- a/iXBRLViewerPlugin/viewer/src/js/fact.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/fact.test.js
@@ -33,6 +33,14 @@ var testReportData = {
                 }
             }
         },
+        "eg:TextBlockConcept1": {
+            "labels": {
+                "std": {
+                    "en": "Text block concept"
+                }
+            },
+            "t": true,
+        },
         "eg:EnumConcept": {
             "labels": {
                 "std": {
@@ -550,20 +558,43 @@ describe("Readable value", () => {
 
     });
 
-    test("Strip HTML tags and normalise whitespace", () => {
+    test("Escaped string", () => {
 
         expect(testFact({ "v": "<b>foo</b>" }, {"escaped": true }).readableValue())
-            .toBe("foo");
+            .toBe("<b>foo</b>");
 
         expect(testFact({ "v": "    <b>foo</b>bar" }, {"escaped": true }).readableValue())
-            .toBe("foobar");
+            .toBe("    <b>foo</b>bar");
 
         expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escaped": true }).readableValue())
+            .toBe("\u00a0<b>foo</b>");
+
+    });
+
+    test("Strip HTML tags and normalise whitespace", () => {
+
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<b>foo</b>" }, {"escaped": true }).readableValue())
+            .toBe("foo");
+
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "    <b>foo</b>bar" }, {"escaped": true }).readableValue())
+            .toBe("foobar");
+
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "\u00a0<b>foo</b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
     });
 
-    test("Don't strip non-escaped facts", () => {
+    test("Strip non-escaped text block facts", () => {
+
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "\u00a0<b>foo</b>" }, {"escaped": false }).readableValue())
+            .toBe("foo");
+
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "\u00a0<b>foo</b>" }, {  }).readableValue())
+            .toBe("foo");
+
+    });
+
+    test("Don't strip non-text-block facts", () => {
 
         expect(testFact({ "v": "\u00a0<b>foo</b>" }, {"escaped": false }).readableValue())
             .toBe("\u00a0<b>foo</b>");
@@ -574,40 +605,40 @@ describe("Readable value", () => {
     });
 
     test("Detect and strip HTML tags - XHTML tags and attributes", () => {
-        expect(testFact({ "v": "<xhtml:b>foo</xhtml:b>" }, {"escaped": true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<xhtml:b>foo</xhtml:b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }, {"escaped": true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": '<xhtml:span style="font-weight: bold">foo</xhtml:span>' }, {"escaped": true }).readableValue())
             .toBe("foo");
     });
 
     test("Detect and strip HTML tags - check behaviour with invalid HTML", () => {
         /* Invalid HTML  */
-        expect(testFact({ "v": "<b:b:b>foo</b:b:b>" }, {"escaped": true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<b:b:b>foo</b:b:b>" }, {"escaped": true }).readableValue())
             .toBe("foo");
 
-        expect(testFact({ "v": "<foo<bar>baz</bar>" }, {"escaped": true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<foo<bar>baz</bar>" }, {"escaped": true }).readableValue())
             .toBe("baz");
     });
 
     test("Text in consecutive inline elements should be contiguous", () => {
 
-        expect(testFact({ "v": "<b>foo</b><i>bar</i>" }, {"escaped":true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<b>foo</b><i>bar</i>" }, {"escaped":true }).readableValue())
             .toBe("foobar");
 
     });
 
     test("Text in block/table elements should be separated.", () => {
 
-        expect(testFact({ "v": "<p>foo</p><p>bar</p>" }, {"escaped":true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<p>foo</p><p>bar</p>" }, {"escaped":true }).readableValue())
             .toBe("foo bar");
 
         /* This should really return "foo bar", but we don't correctly detect
          * block tags in prefixed XHTML */
-        expect(testFact({ "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }, {"escaped":true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": '<xhtml:p xmlns:xhtml="https://www.w3.org/1999/xhtml/">foo</xhtml:p><xhtml:p>bar</xhtml:p>' }, {"escaped":true }).readableValue())
             .toBe("foobar");
 
-        expect(testFact({ "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" }, {"escaped":true })
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<table><tr><td>cell1</td><td>cell2</td></tr></table>" }, {"escaped":true })
             .readableValue())
             .toBe("cell1 cell2");
 
@@ -615,7 +646,7 @@ describe("Readable value", () => {
 
     test("Whitespace normalisation", () => {
 
-        expect(testFact({ "v": "<p>bar  foo</p> <p>bar</p>" }, {"escaped":true }).readableValue())
+        expect(testFact({ "a": { "c": "eg:TextBlockConcept1" }, "v": "<p>bar  foo</p> <p>bar</p>" }, {"escaped":true }).readableValue())
             .toBe("bar foo bar");
 
     });


### PR DESCRIPTION
#### Reason for change
Ideally, text block facts should always be parsed and rendered as HTML, and non-text-block concept types should always be rendered literally.  We correctly only show rendered HTML for text block facts, but we incorrectly unescape non-text-block values when rendering the value inline.

#### Description of change
The readable value of a fact should be based on whether it's a text block, not whether it's escaped.

#### Steps to Test
The facts in [p-2024-03-14-en.zip](https://github.com/Arelle/ixbrl-viewer/files/14603455/p-2024-03-14-en.zip) are using `stringItemType` and should be rendered as `a&amp;b` and `c&amp;d`, not `a&b` and `c&d`.

**review**:
@Arelle/arelle
@paulwarren-wk
