### PR TITLE
Ignore absolutely-positioned content containers

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixnode.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixnode.js
@@ -46,6 +46,6 @@ export class IXNode {
     }
 
     htmlHidden() {
-        return this.wrapperNodes.is(':hidden') || this.wrapperNodes.is((i,e) => isTransparent($(e).css('color')));
+        return this.wrapperNodes.filter(':not(.ixbrl-no-highlight)').is(':hidden') || this.wrapperNodes.is((i,e) => isTransparent($(e).css('color')));
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -593,7 +593,7 @@ export class Viewer {
     /* If the specified element is not fully visible, scroll it into the center of
      * the viewport */
     showElement(e) {
-        const ee = e.get(0);
+        const ee = e.filter(':not(.ixbrl-no-highlight)').get(0);
         if (!this.isFullyVisible(ee)) {
             ee.scrollIntoView({ block: "center", inline: "center" });
         }


### PR DESCRIPTION
For elements that only have absolutely positioned children, don't attempt to navigate to them using next/prev buttons, and ignore the fact that they're not visible when detecting concealed tags.

#### Reason for change

Fixes #647 

Also fixes a related problem with next/prev navigation not working.

#### Description of change

When deciding whether a fact is "concealed", or when navigating to a fact, ignore wrapper nodes that have the `ixbrl-no-highlight` class.  This indicates that they have zero size, and they may be rendered in a different location to the fact itself.

#### Steps to Test

Using [this document](https://filings.xbrl.org/filing/2221005IWV4R4EP4D553-2023-12-31-ESEF-IT-0), select any table tag, and confirm that it is not considered to be a "concealed tag".   Also confirm that navigating to facts (e.g. by search selection, or next/prev) works causes the fact to be scrolled  into view.

**review**:
@Arelle/arelle
@paulwarren-wk
