### PR TITLE
Default value for `viewerURL` when using Arelle Python API

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -109,7 +109,7 @@ def iXBRLViewerCommandLineOptionExtender(parser, *args, **kwargs):
 def generateViewer(
         cntlr: Cntlr,
         saveViewerDest: io.BytesIO | str | None,
-        viewerURL: str = DEFAULT_VIEWER_PATH,
+        viewerURL: str | None = None,
         showValidationMessages: bool = False,
         useStubViewer: bool = False,
         zipViewerOutput: bool = False,
@@ -136,9 +136,7 @@ def generateViewer(
         cntlr.addToLog(f"iXBRL Viewer destination not provided. {abortGenerationMsg}", messageCode=EXCEPTION_MESSAGE_CODE)
         return
 
-    if not viewerURL:
-        cntlr.addToLog(f"iXBRL Viewer script not provided. {abortGenerationMsg}", messageCode=EXCEPTION_MESSAGE_CODE)
-        return
+    viewerURL = viewerURL or DEFAULT_VIEWER_PATH
 
     if (cntlr.modelManager is None
         or len(cntlr.modelManager.loadedModelXbrls) == 0
@@ -224,7 +222,7 @@ def iXBRLViewerSaveCommand(cntlr):
         generateViewer(
             cntlr=cntlr,
             saveViewerDest=dialog.filename(),
-            viewerURL=dialog.scriptUrl() or DEFAULT_VIEWER_PATH,
+            viewerURL=dialog.scriptUrl(),
             copyScript=dialog.copyScript(),
             zipViewerOutput=dialog.zipViewerOutput(),
             features=dialog.features(),
@@ -305,7 +303,7 @@ def guiRun(cntlr, modelXbrl, attach, *args, **kwargs):
         generateViewer(
             cntlr=cntlr,
             saveViewerDest=tempViewer.name,
-            viewerURL=cntlr.config.get(CONFIG_SCRIPT_URL) or DEFAULT_VIEWER_PATH,
+            viewerURL=cntlr.config.get(CONFIG_SCRIPT_URL),
             copyScript=cntlr.config.get(CONFIG_COPY_SCRIPT, DEFAULT_COPY_SCRIPT),
             useStubViewer=True,
             features=features,


### PR DESCRIPTION
#### Reason for change
Using the plugin from the Arelle Python API means not having access to command line argument defaults. It would be nice to not have to provide `viewerURL` in `RuntimeOptions` and have the default value take its place.

#### Steps to Test
Fairly straight forward change, but if you're curious to test it you can construct a `RuntimeOptions` instance:
```
RuntimeOptions(
    entrypointFile=str(target_path),
    keepOpen=True,
    pluginOptions={
        'saveViewerDest': str(viewer_path),
    },
    plugins='ixbrl-viewer',
)
``` 
and pass it into `CntlrCmdLine`

**review**:
@Arelle/arelle
@paulwarren-wk
