### PR TITLE
Add square brackets to untagged number matching guards

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/number-matcher.js
+++ b/iXBRLViewerPlugin/viewer/src/js/number-matcher.js
@@ -47,9 +47,9 @@ const hyphen = '[-\u2014]';
 
 // everything that we allow immediately before a match 
 // (201c = left double quote, 2014 = em dash, 201d = right double quote)
-const begin_guard = '(?:^|(?<=(?:[/\u201c\u2014(]|' + one_ws + '|' + hyphen + ')))';
+const begin_guard = '(?:^|(?<=(?:[[/\u201c\u2014(]|' + one_ws + '|' + hyphen + ')))';
 // everything that we allow immediately after a match
-const end_guard = '(?:$|(?=(?:[/,.:;\u201d\u2014)]|' + one_ws + '|' + hyphen + ')))';
+const end_guard = '(?:$|(?=(?:[\\]/,.:;\u201d\u2014)]|' + one_ws + '|' + hyphen + ')))';
 
 const ordinal_suffix = '(?:st|nd|rd|th)';
 const day = '[123]?\\d' + ordinal_suffix + '?';

--- a/iXBRLViewerPlugin/viewer/src/js/number-matcher.js
+++ b/iXBRLViewerPlugin/viewer/src/js/number-matcher.js
@@ -47,9 +47,9 @@ const hyphen = '[-\u2014]';
 
 // everything that we allow immediately before a match 
 // (201c = left double quote, 2014 = em dash, 201d = right double quote)
-const begin_guard = '(?:^|(?<=(?:[[/\u201c\u2014(]|' + one_ws + '|' + hyphen + ')))';
+const begin_guard = '(?:^|(?<=(?:[/\u201c\u2014([]|' + one_ws + '|' + hyphen + ')))';
 // everything that we allow immediately after a match
-const end_guard = '(?:$|(?=(?:[\\]/,.:;\u201d\u2014)]|' + one_ws + '|' + hyphen + ')))';
+const end_guard = '(?:$|(?=(?:[/,.:;\u201d\u2014)\\]]|' + one_ws + '|' + hyphen + ')))';
 
 const ordinal_suffix = '(?:st|nd|rd|th)';
 const day = '[123]?\\d' + ordinal_suffix + '?';


### PR DESCRIPTION
#### Reason for change
In review mode, untagged number highlighting was missing numbers prefixed with `[` or suffixed with `]`.

#### Description of change
Add `[` and `]` to guard regex.

#### Steps to Test
Before:
![before](https://github.com/Arelle/ixbrl-viewer/assets/105066394/77de0940-991e-4afa-9ea1-5e5072496f93)

After:
![after](https://github.com/Arelle/ixbrl-viewer/assets/105066394/1c270f67-c09d-4d7f-82ef-c45d2d2e1fac)

**review**:
@Arelle/arelle
@paulwarren-wk
