### PR TITLE
Display extracted software vendor names in summary panel

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -407,11 +407,12 @@ class IXBRLViewerBuilder:
         for n, report in enumerate(self.reports):
             self.footnoteRelationshipSet = ModelRelationshipSet(report, "XBRL-footnotes")
             self.currentTargetReport = self.newTargetReport(getattr(report, "ixdsTarget", None))
-            softwareCredits = {
-                match
-                for document in report.urlDocs.values()
-                for match in document.creationSoftwareMatches(document.creationSoftwareComment)
-            }
+            softwareCredits = set()
+            for document in report.urlDocs.values():
+                if document.type not in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET):
+                    continue
+                matches = document.creationSoftwareMatches(document.creationSoftwareComment)
+                softwareCredits.update(matches)
             if softwareCredits:
                 self.currentTargetReport["softwareCredits"] = list(softwareCredits)
             for f in report.facts:

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -407,6 +407,13 @@ class IXBRLViewerBuilder:
         for n, report in enumerate(self.reports):
             self.footnoteRelationshipSet = ModelRelationshipSet(report, "XBRL-footnotes")
             self.currentTargetReport = self.newTargetReport(getattr(report, "ixdsTarget", None))
+            softwareCredits = {
+                match
+                for document in report.urlDocs.values()
+                for match in document.creationSoftwareMatches(document.creationSoftwareComment)
+            }
+            if softwareCredits:
+                self.currentTargetReport["softwareCredits"] = list(softwareCredits)
             for f in report.facts:
                 self.addFact(report, f)
             self.currentTargetReport["rels"] = self.getRelationships(report)

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -346,6 +346,12 @@ See COPYRIGHT.md for copyright information
               </div>
             </div>
           </div>
+          <div class="collapsible-section software">
+            <h3 class="collapsible-header" data-i18n="inspector.summary.filingSoftware">Filing Software</h3>
+            <div class="collapsible-body">
+              <ul></ul>
+            </div>
+          </div>
         </div>
       </div>
 

--- a/iXBRLViewerPlugin/viewer/src/html/inspector.html
+++ b/iXBRLViewerPlugin/viewer/src/html/inspector.html
@@ -346,8 +346,8 @@ See COPYRIGHT.md for copyright information
               </div>
             </div>
           </div>
-          <div class="collapsible-section software">
-            <h3 class="collapsible-header" data-i18n="inspector.summary.filingSoftware">Filing Software</h3>
+          <div class="collapsible-section report-creation">
+            <h3 class="collapsible-header" data-i18n="inspector.summary.reportCreation">Report Creation</h3>
             <div class="collapsible-body">
               <ul></ul>
             </div>

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -98,7 +98,8 @@
         "other": "Other Linkbases",
         "presentation": "Presentation Linkbases",
         "references": "Reference Linkbases",
-        "schemas": "Schemas"
+        "schemas": "Schemas",
+        "filingSoftware": "Filing Software"
       },
       "tag": {
         "colDimensions": "Dimensions",

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -99,7 +99,7 @@
         "presentation": "Presentation Linkbases",
         "references": "Reference Linkbases",
         "schemas": "Schemas",
-        "filingSoftware": "Filing Software"
+        "reportCreation": "Report Creation"
       },
       "tag": {
         "colDimensions": "Dimensions",

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -99,7 +99,7 @@
         "presentation": "",
         "references": "",
         "schemas": "",
-        "filingSoftware": ""
+        "reportCreation": ""
       },
       "tag": {
         "colDimensions": "",

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -98,7 +98,8 @@
         "other": "",
         "presentation": "",
         "references": "",
-        "schemas": ""
+        "schemas": "",
+        "filingSoftware": ""
       },
       "tag": {
         "colDimensions": "",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -516,7 +516,7 @@ export class Inspector {
         this._populateFactSummary(summaryDom);
         this._populateTagSummary(summaryDom);
         this._populateFileSummary(summaryDom);
-        this._populateFilingSoftware(summaryDom);
+        this._populateReportCreation(summaryDom);
     }
 
     _populateFactSummary(summaryDom) {
@@ -617,18 +617,18 @@ export class Inspector {
         }
     };
 
-    _populateFilingSoftware(summaryDom) {
+    _populateReportCreation(summaryDom) {
         const softwareCredits = this.summary.getSoftwareCredits();
 
-        const filingSoftwareContent = summaryDom.find(".software");
+        const reportCreationContent = summaryDom.find(".report-creation");
 
         if (softwareCredits.length > 0) {
-            const ul = filingSoftwareContent.find('ul');
+            const ul = reportCreationContent.find('ul');
             for (const softwareCredit of softwareCredits) {
                 ul.append($("<li></li>").text(softwareCredit));
             }
         } else {
-            filingSoftwareContent.hide();
+            reportCreationContent.hide();
         }
     };
 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -516,6 +516,7 @@ export class Inspector {
         this._populateFactSummary(summaryDom);
         this._populateTagSummary(summaryDom);
         this._populateFileSummary(summaryDom);
+        this._populateFilingSoftware(summaryDom);
     }
 
     _populateFactSummary(summaryDom) {
@@ -613,6 +614,21 @@ export class Inspector {
         insertFileSummary(unrecognizedLinkbase, ".other-links");
         if (visibleItems == 0) {
             summaryFilesContent.hide();
+        }
+    };
+
+    _populateFilingSoftware(summaryDom) {
+        const softwareCredits = this.summary.getSoftwareCredits();
+
+        const filingSoftwareContent = summaryDom.find(".software");
+
+        if (softwareCredits.length > 0) {
+            const ul = filingSoftwareContent.find('ul');
+            for (const softwareCredit of softwareCredits) {
+                ul.append($("<li></li>").text(softwareCredit));
+            }
+        } else {
+            filingSoftwareContent.hide();
         }
     };
 

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -266,4 +266,17 @@ export class XBRLReport {
         }
         return this._calculationSummations.has(c);
     }
+
+
+    /**
+     * @return {Array[String]} Software credit text labels provided with this report for display purposes.
+     */
+    softwareCredits() {
+        if (!this._reportData.softwareCredits) {
+            return [];
+        }
+        // Arelle defaults to "None" if no comment text is found. This will be null for our purposes.
+        return this._reportData.softwareCredits
+                .filter(c => c !== "None");
+    }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/report.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.js
@@ -272,11 +272,6 @@ export class XBRLReport {
      * @return {Array[String]} Software credit text labels provided with this report for display purposes.
      */
     softwareCredits() {
-        if (!this._reportData.softwareCredits) {
-            return [];
-        }
-        // Arelle defaults to "None" if no comment text is found. This will be null for our purposes.
-        return this._reportData.softwareCredits
-                .filter(c => c !== "None");
+        return this._reportData.softwareCredits ?? [];
     }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -158,17 +158,6 @@ describe("Fetching software credit", () => {
         expect(softwareCredits).toEqual(["Example credit text A", "Example credit text B"]);
     });
 
-    test("'None' value", () => {
-        let alternateData = JSON.parse(JSON.stringify(testReportData));
-        alternateData.softwareCredits = ["None"];
-        const testReportSet = new ReportSet(alternateData);
-        testReportSet._initialize();
-        const report = testReportSet.reports[0];
-
-        const softwareCredits = report.softwareCredits();
-        expect(softwareCredits).toEqual([]);
-    });
-
     test("Unset", () => {
         let alternateData = JSON.parse(JSON.stringify(testReportData));
         delete alternateData.softwareCredits;

--- a/iXBRLViewerPlugin/viewer/src/js/report.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/report.test.js
@@ -62,7 +62,9 @@ var testReportData = {
                 "p": "2018-01-01/2019-01-01",
             }
         }
-    }
+    },
+
+    "softwareCredits": ["Example credit text A", "Example credit text B"],
 };
 
 
@@ -143,4 +145,38 @@ describe("ELR labels", () => {
         expect(testReport.getRoleLabel("role4")).toBe("https://www.example.com/role4");
     });
 
+});
+
+describe("Fetching software credit", () => {
+
+    test("Successful", () => {
+        const testReportSet = new ReportSet(testReportData);
+        testReportSet._initialize();
+        const report = testReportSet.reports[0];
+
+        const softwareCredits = report.softwareCredits();
+        expect(softwareCredits).toEqual(["Example credit text A", "Example credit text B"]);
+    });
+
+    test("'None' value", () => {
+        let alternateData = JSON.parse(JSON.stringify(testReportData));
+        alternateData.softwareCredits = ["None"];
+        const testReportSet = new ReportSet(alternateData);
+        testReportSet._initialize();
+        const report = testReportSet.reports[0];
+
+        const softwareCredits = report.softwareCredits();
+        expect(softwareCredits).toEqual([]);
+    });
+
+    test("Unset", () => {
+        let alternateData = JSON.parse(JSON.stringify(testReportData));
+        delete alternateData.softwareCredits;
+        const testReportSet = new ReportSet(alternateData);
+        testReportSet._initialize();
+        const report = testReportSet.reports[0];
+
+        const softwareCredits = report.softwareCredits();
+        expect(softwareCredits).toEqual([]);
+    });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.js
@@ -117,6 +117,14 @@ export class ReportSet {
         return this._usedPrefixes;
     }
 
+    /**
+     * @return {Array[String]} Sorted list of unique software credit text values
+     */
+    getSoftwareCredits() {
+        let softwareCredits = new Set(this.reports.flatMap(r => r.softwareCredits()));
+        return Array.from(softwareCredits).sort();
+    }
+
     getTargetDocuments() {
         if (this._targetDocuments === undefined) {
             this._targetDocuments = new Set(Object.values(this._items)

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.test.js
@@ -73,7 +73,10 @@ function multiReportTestData(withAnchoring) {
                         "facts": {
                             ...createNumericFact("f1", "eg:Concept1", "iso2417:USD", "2018-01-01/2019-01-01", 1000, -3),
                             ...createNumericFact("f2", "eg:Concept2", "iso2417:USD", "2018-01-01/2019-01-01", 1000, -3),
-                        }
+                        },
+
+
+                        "softwareCredits": ["Example credit text C", "Example credit text B"],
                     },
                 ]
             },
@@ -112,7 +115,9 @@ function multiReportTestData(withAnchoring) {
 
                         "rels": {
                           ...anchoringRelationShips(withAnchoring)
-                        }
+                        },
+
+                        "softwareCredits": ["Example credit text A"],
                     }
                 ]
             }
@@ -165,7 +170,9 @@ function singleReportTestData() {
         "facts": {
             ...createNumericFact("f1", "eg:Concept1", "iso2417:USD", "2018-01-01/2019-01-01", 1000, -3),
             ...createNumericFact("f2", "eg:Concept2", "iso2417:USD", "2018-01-01/2019-01-01", 1000, -3),
-        }
+        },
+
+        "softwareCredits": ["Example credit text"],
     };
 }
 
@@ -327,5 +334,24 @@ describe("ELR labels", () => {
 
     test("Present", () => {
         expect(testReportSet.reports[0].getRoleLabel("role1")).toBe("Role 1 Label");
+    });
+});
+
+describe("Fetching software credit", () => {
+
+    test("Single", () => {
+        const testReportSet = new ReportSet(singleReportTestData());
+        testReportSet._initialize();
+
+        const softwareCredits = testReportSet.getSoftwareCredits();
+        expect(softwareCredits).toEqual(["Example credit text"]);
+    });
+
+    test("Multiple", () => {
+        const testReportSet = new ReportSet(multiReportTestData(true));
+        testReportSet._initialize();
+
+        const softwareCredits = testReportSet.getSoftwareCredits();
+        expect(softwareCredits).toEqual(["Example credit text A", "Example credit text B", "Example credit text C"]);
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/summary.js
+++ b/iXBRLViewerPlugin/viewer/src/js/summary.js
@@ -138,4 +138,12 @@ export class DocumentSummary {
         }
         return this._localFileSummary.getDocuments()
     }
+
+
+    /**
+     * @return {Array[String]} Report set's list of software credit text values.
+     */
+    getSoftwareCredits() {
+        return this._reportSet.getSoftwareCredits();
+    }
 }

--- a/iXBRLViewerPlugin/viewer/src/js/summary.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/summary.test.js
@@ -17,16 +17,17 @@ function testFact(conceptName, dimensions) {
     }
 }
 
-function testReportSet(concepts, facts, documents) {
+function testReportSet(concepts, facts, documents, softwareCredits) {
     const report = {
         getConcept: conceptName => concepts[conceptName],
-        localDocuments: () => documents
+        localDocuments: () => documents,
     }
     for (const f of facts) {
         f.report = report;
     }
     return {
         facts: () => facts,
+        getSoftwareCredits: () => softwareCredits,
         reports: [ report ]
     }
 }
@@ -34,7 +35,7 @@ function testReportSet(concepts, facts, documents) {
 describe("Facts summary", () => {
 
     test("no facts", () => {
-        const reportSet = testReportSet({}, [], {});
+        const reportSet = testReportSet({}, [], {}, []);
         const summary = new DocumentSummary(reportSet);
 
         expect(summary.totalFacts()).toBe(0);
@@ -43,9 +44,9 @@ describe("Facts summary", () => {
     test("multiple facts", () => {
         const facts = [];
         for (let i = 0; i < 10; i++) {
-            facts.push(testFact("eg:Concept1", {}));
+            facts.push(testFact("eg:Concept1", {}, []));
         }
-        const reportSet = testReportSet({}, facts, {});
+        const reportSet = testReportSet({}, facts, {}, []);
         const summary = new DocumentSummary(reportSet);
 
         expect(summary.totalFacts()).toBe(10);
@@ -55,7 +56,7 @@ describe("Facts summary", () => {
         const conceptName = "eg:Concept1";
         const fact1 = testFact(conceptName, {});
         const fact2 = testFact(conceptName, {});
-        const reportSet = testReportSet({}, [fact1, fact2], {});
+        const reportSet = testReportSet({}, [fact1, fact2], {}, []);
         const summary = new DocumentSummary(reportSet);
 
         expect(summary.totalFacts()).toBe(2);
@@ -66,7 +67,7 @@ describe("Facts summary", () => {
 describe("Tags summary", () => {
 
     test("no tags", () => {
-        const reportSet = testReportSet({}, [], {})
+        const reportSet = testReportSet({}, [], {}, [])
         const summary = new DocumentSummary(reportSet);
 
         expect(summary.tagCounts()).toEqual(new Map());
@@ -76,7 +77,7 @@ describe("Tags summary", () => {
         const fact1 = testFact("eg:Concept1", {});
         const fact2 = testFact("eg:Concept2", {});
         const fact3 = testFact("xz:Concept1", {});
-        const reportSet = testReportSet({}, [fact1, fact2, fact3], {})
+        const reportSet = testReportSet({}, [fact1, fact2, fact3], {}, [])
         const summary = new DocumentSummary(reportSet);
 
         expect(Object.fromEntries(summary.tagCounts())).toEqual({
@@ -105,7 +106,7 @@ describe("Tags summary", () => {
         const concepts = {
             [dimension]: testConcept(),
         }
-        const reportSet = testReportSet(concepts, [fact], {})
+        const reportSet = testReportSet(concepts, [fact], {}, [])
         const summary = new DocumentSummary(reportSet);
 
         expect(Object.fromEntries(summary.tagCounts())).toEqual({
@@ -135,7 +136,7 @@ describe("Tags summary", () => {
             [dimension2]: testConcept(),
             [dimension3]: testConcept(),
         }
-        const reportSet = testReportSet(concepts, [fact], {})
+        const reportSet = testReportSet(concepts, [fact], {}, [])
         const summary = new DocumentSummary(reportSet);
 
         expect(Object.fromEntries(summary.tagCounts())).toEqual({
@@ -176,7 +177,7 @@ describe("Tags summary", () => {
         const concepts = {
             [dimension]: testConcept(typedDomain),
         }
-        const reportSet = testReportSet(concepts, [fact], {})
+        const reportSet = testReportSet(concepts, [fact], {}, [])
         const summary = new DocumentSummary(reportSet);
 
         expect(Object.fromEntries(summary.tagCounts())).toEqual({
@@ -200,7 +201,7 @@ describe("Files summary", () => {
 
     test("no files", () => {
         const documentData = {}
-        const reportSet = testReportSet({}, [], documentData);
+        const reportSet = testReportSet({}, [], documentData, []);
         const summary = new DocumentSummary(reportSet);
 
         expect(summary.getLocalDocuments()).toEqual({
@@ -228,7 +229,7 @@ describe("Files summary", () => {
             'labelLinkbase.xml': ['labelLinkbase'],
             'unrecognizedLinkbase.xml': ['unrecognizedLinkbase'],
         }
-        const reportSet = testReportSet({}, [], documentData);
+        const reportSet = testReportSet({}, [], documentData, []);
         const summary = new DocumentSummary(reportSet);
 
         expect(summary.getLocalDocuments()).toEqual({
@@ -241,5 +242,41 @@ describe("Files summary", () => {
             refLinkbase: ['refLinkbase1.xml', 'refLinkbase2.xml'],
             unrecognizedLinkbase: ['unrecognizedLinkbase.xml'],
         });
+    });
+});
+
+describe("Software credit", () => {
+
+    test("no credits", () => {
+        const softwareCredits = []
+        const documentData = {}
+        const reportSet = testReportSet({}, [], documentData, softwareCredits);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.getSoftwareCredits()).toEqual([]);
+    });
+
+    test("one credit", () => {
+        const softwareCredits = ["Example credit text"]
+        const documentData = {}
+        const reportSet = testReportSet({}, [], documentData, softwareCredits);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.getSoftwareCredits()).toEqual(["Example credit text"]);
+    });
+
+    test("multiple credits", () => {
+        const softwareCredits = [
+            "Example credit text A",
+            "Example credit text B",
+        ]
+        const documentData = {}
+        const reportSet = testReportSet({}, [], documentData, softwareCredits);
+        const summary = new DocumentSummary(reportSet);
+
+        expect(summary.getSoftwareCredits()).toEqual([
+            "Example credit text A",
+            "Example credit text B",
+        ]);
     });
 });

--- a/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
+++ b/tests/unit_tests/iXBRLViewerPlugin/test_iXBRLViewer.py
@@ -296,6 +296,9 @@ class TestIXBRLViewer:
             format='format'
         )
 
+        def creationSoftwareMatches_effect(text):
+            return ["Example Software Name"]
+
         def fromModelObjects_effect(concept):
             return []
 
@@ -372,6 +375,7 @@ class TestIXBRLViewer:
 
         def urlDocEntry(path, docType, linkQName=None):
             return path, Mock(
+                creationSoftwareMatches=creationSoftwareMatches_effect,
                 type=docType,
                 basename=os.path.basename(path),
                 xmlRootElement=Mock(
@@ -523,6 +527,7 @@ class TestIXBRLViewer:
         errors = jsdata["validation"]
         assert errors == [{"sev": "ERROR", "msg": "Error message", "code": "code1" }]
         assert set(jsdata["sourceReports"][0]["targetReports"][0]["facts"]) == {"fact_id1", "fact_typed_dimension", "fact_dimension_missing_member"}
+        assert jsdata["sourceReports"][0]["targetReports"][0]["softwareCredits"] == ["Example Software Name"]
 
     @patch('arelle.XbrlConst.conceptLabel', 'http://www.xbrl.org/2003/arcrole/concept-label')
     @patch('arelle.XbrlConst.conceptReference', 'http://www.xbrl.org/2003/arcrole/concept-reference')


### PR DESCRIPTION
#### Reason for change
To allow for more prominent display of software credits associated with a filing that would otherwise be only visible in comments.

#### Description of change
- For each report, retrieve software vendor names from each associated document and store in `softwareCredits` within corresponding JSON object
- When rendering a report summary, display each software vendor name under "Report Creation" section

#### Steps to Test
Example filing with single name match: 
[credittest_name_match.zip](https://github.com/Arelle/ixbrl-viewer/files/15410350/credittest_name_match.zip)
<img width="439" alt="Screenshot 2024-05-22 at 7 17 12 PM" src="https://github.com/Arelle/ixbrl-viewer/assets/105066394/687c575f-7108-40a1-b17b-1a78676fb390">

Example filing with multiple pattern matches:
[credittest_pattern_match.zip](https://github.com/Arelle/ixbrl-viewer/files/15410354/credittest_pattern_match.zip)
<img width="441" alt="Screenshot 2024-05-22 at 7 16 55 PM" src="https://github.com/Arelle/ixbrl-viewer/assets/105066394/f4232949-3fb3-445d-a9a4-887801847d93">



**review**:
@Arelle/arelle
@paulwarren-wk
