### PR TITLE
Try to use xml:lang to set html lang

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -157,7 +157,7 @@ export class iXBRLViewer {
             docTitle = "Inline Viewer";
         }
         if ($('html').attr("lang") === undefined) {
-            $('html').attr("lang", "en-US");
+            $('html').attr("lang", $('html').attr("xml:lang") || "en-US");
         }
 
         $('head').children().not("script").not("style#ixv-style").not("link#ixv-favicon").appendTo($(iframe).contents().find('head'));


### PR DESCRIPTION
#### Reason for change
The default lang value of `en-US` potentially conflicts with `xml:lang` if present.

#### Description of change
First check if there's an `xml:lang` value to use before falling back to `en-US` when setting `lang`.

#### Steps to Test
Note: this doesn't impact the stub viewer, so this must be tested from the command line.
* Use [a report with a non English xml:lang value](https://github.com/Arelle/ixbrl-viewer/files/15476117/austin-2024-05-28-fr.zip).
* `python arelleCmdLine.py --plugins ixbrl-viewer --file austin-2024-05-28-fr.zip --save-viewer ixbrlviewer.html`
* Load the viewer in a web browser and confirm that the `xml:lang` and `lang` attributes on the html element match (`fr`).

**review**:
@Arelle/arelle
@paulwarren-wk
