### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,15 @@
+.idea
+.mypy_cache
+.pytest_cache
+.tox
+.vscode
+/ixbrl-viewer*.tgz
+/tests/puppeteer/artifacts/
+Pipfile*
+__pycache__
+build
+iXBRLViewerPlugin/_version.py
+iXBRLViewerPlugin/viewer/src/fonts/
+iXBRLViewerPlugin/viewer/src/less/generated/
+ixbrl_viewer.egg-info
+node_modules/


### PR DESCRIPTION
#### Reason for change
`npm pack` intends to exclude files included in `.gitignore`, so the `dist/` directory *should* have been excluded from packages published in the past. 
A recent `npm` release included a correction to a faulty handling of `.gitignore`, so `dist/` now became excluded (as intended by `npm pack`) in releases starting with 1.4.23.

#### Description of change
To resolve the issue, we can decouple our `.gitignore` entries from what's included in the npm package by adding a `.npmignore` file that `npm pack` considers as an override to `.gitignore` for its purposes.

#### Steps to Test
For both an older version of node (20.11.1, used to release 1.4.22), and the lastest version of node, I ran `npm pack` and compared the file listing output to confirm no unexpected differences.

One could repeat this to confirm, or simply just confirm afterwards that the released package looks as expected.

**review**:
@Arelle/arelle
@paulwarren-wk
