### PR TITLE
Support for Calculation 1.1 relationships

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -190,7 +190,7 @@ class IXBRLViewerBuilder:
 
         for baseSetKey, baseSetModelLinks  in report.baseSets.items():
             arcrole, ELR, linkqname, arcqname = baseSetKey
-            if arcrole in (XbrlConst.summationItem, WIDER_NARROWER_ARCROLE, XbrlConst.parentChild, XbrlConst.dimensionDefault) and ELR is not None:
+            if arcrole in (XbrlConst.summationItem, XbrlConst.summationItem11, WIDER_NARROWER_ARCROLE, XbrlConst.parentChild, XbrlConst.dimensionDefault) and ELR is not None:
                 self.addELR(report, ELR)
                 rr = dict()
                 relSet = report.relationshipSet(arcrole, ELR)
@@ -395,6 +395,7 @@ class IXBRLViewerBuilder:
         self.roleMap.getPrefix(XbrlConst.standardLabel, "std")
         self.roleMap.getPrefix(XbrlConst.documentationLabel, "doc")
         self.roleMap.getPrefix(XbrlConst.summationItem, "calc")
+        self.roleMap.getPrefix(XbrlConst.summationItem11, "calc11")
         self.roleMap.getPrefix(XbrlConst.parentChild, "pres")
         self.roleMap.getPrefix(XbrlConst.dimensionDefault, "d-d")
         self.roleMap.getPrefix(WIDER_NARROWER_ARCROLE, "w-n")

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -23,6 +23,7 @@
     "calculationIsConsistent": "Calculation is consistent",
     "calculationIsInconsistent": "Calculation is inconsistent",
     "calculationUnchecked": "Calculation not checked due to presence of duplicate facts",
+    "calculationUncheckedIncorrectVersion": "Calculation 1.1 relationships not checked in legacy calculation mode",
     "change": "Change",
     "changeFromIn": "From {{from}} in ",
     "changePercentageDecrease": "{{decrease}}% decrease on ",

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -821,7 +821,12 @@ export class Inspector {
                 calcStatusIcon
                     .addClass("unchecked-flag")
                     .attr("title", i18next.t('factDetails.calculationUnchecked'))
-                calcStatusText.text(i18next.t('factDetails.calculationUnchecked'));
+                if (rCalc.uncheckedDueToVersionMismatch()) {
+                    calcStatusText.text(i18next.t('factDetails.calculationUncheckedIncorrectVersion'));
+                }
+                else {
+                    calcStatusText.text(i18next.t('factDetails.calculationUnchecked'));
+                }
             }
 
             a.addCard(cardTitle, calcBody, rCalc.elr == selectedELR);

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -9,6 +9,9 @@ export const SHOW_FACT = 'SHOW_FACT';
 
 export const NAMESPACE_ISO4217 = 'http://www.xbrl.org/2003/iso4217';
 
+export const CALC_ARCROLE = "calc";
+export const CALC11_ARCROLE = "calc11";
+
 // The number of distinct highlight colors defined in inspector.less
 export const HIGHLIGHT_COLORS = 3;
 


### PR DESCRIPTION
#### Reason for change

Although we already have a mode for applying Calc 1.1 semantics to legacy calculation relationships, reports using Calculation 1.1 relationships in the taxonomy did not show any calculation relationships in the viewer.

#### Description of change

Calculations 1.1 relationships are now included in the JSON taxonomy data.  The viewer will now show calculations defined using either relationship type, but if a total has both types in a single ELR, Calc 1.1 takes precedence.

#### Steps to Test

Prepare a report using the Calc 1.1 summation-item relationship, and confirm that calculations are shown in the viewer.  Example below is a filing that has been modified to use the the new arcrole:

[wk-calc11.zip](https://github.com/Arelle/ixbrl-viewer/files/15491364/wk-calc11.zip)


**review**:
@Arelle/arelle
@paulwarren-wk
