### PR TITLE
EDGAR workflow-specific operational change

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -132,6 +132,7 @@ def generateViewer(
         features: list[str] | None = None,
         packageDownloadURL: str | None = None,
         copyScript: bool = True,
+        stubFileOnly: bool = False,
 ) -> None:
     """
     Generate and save an iXBRL viewer at the given destination (file, directory, or in-memory file) with the given viewer script URL.
@@ -145,6 +146,7 @@ def generateViewer(
     :param features: Optional list of features to enable.
     :param packageDownloadURL: Optional URL to use as the report package download URL.
     :param copyScript: Controls if the script referenced by viewerURL is copied into the output directory, or directly set as the 'src' value of the script tag in the HTML iXBRL Viewer.
+    :param stubFileOnly: Controls if the output zip is to only contain the stub file.
     """
     # extend XBRL-loaded run processing for this option
     abortGenerationMsg = "Skipping iXBRL Viewer generation."
@@ -189,7 +191,7 @@ def generateViewer(
                 bldr.enableFeature(feature)
         iv = bldr.createViewer(scriptUrl=viewerURL, showValidations=showValidationMessages, packageDownloadURL=packageDownloadURL)
         if iv is not None:
-            iv.save(saveViewerDest, zipOutput=zipViewerOutput, copyScriptPath=copyScriptPath)
+            iv.save(saveViewerDest, zipOutput=zipViewerOutput, copyScriptPath=copyScriptPath, stubFileOnly=stubFileOnly)
     except IXBRLViewerBuilderError as ex:
         print(ex)
     except Exception as ex:

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -546,7 +546,7 @@ class iXBRLViewer:
     def addFilingDoc(self, filingDocuments):
         self.filingDocuments = filingDocuments
 
-    def save(self, destination: io.BytesIO | str, zipOutput: bool = False, copyScriptPath: Path | None = None):
+    def save(self, destination: io.BytesIO | str, zipOutput: bool = False, copyScriptPath: Path | None = None, stubFileOnly: bool = False):
         """
         Save the iXBRL viewer.
         :param destination: The target that viewer data/files will be written to (path to file/directory, or a file object itself).
@@ -584,7 +584,9 @@ class iXBRLViewer:
                     with zout.open(f.filename, "w") as fout:
                         writer = XHTMLSerializer(fout)
                         writer.serialize(f.xmlDocument)
-                if self.filingDocuments:
+                    if stubFileOnly:
+                        break # only output the stub file
+                if not stubFileOnly and self.filingDocuments:
                     filename = os.path.basename(self.filingDocuments)
                     self.cntlr.addToLog("Writing %s" % filename, messageCode=INFO_MESSAGE_CODE)
                     zout.write(self.filingDocuments, filename)


### PR DESCRIPTION
#### Reason for change
This change is a companion to [EdgarRenderer Pull Request #114](https://github.com/Arelle/EdgarRenderer/pull/114)

With the Edgar workflow the iXBRLViewer stub is generated twice (for the situation of private and redacted public viewers), not by the usual plugin invocation but instead invoked from an EdgarRenderer iXBRLViewerPluginInterface module.

EdgarRenderer provides unique fact IDs because they're also needed by EDGAR's ixviewer-plus.

It adds a stubOnly flag to generateViewer, so that when saving (into an io.bytes zip) only the stub is saved.  The source files are not readable because they may either be encrypted or in a POSTED zip source, but not plain filesystem files.  The source files also may not represent the redacted publicly disseminatable files.

#### Description of change
Add stub-only parameter. 

#### Steps to Test

**review**:
@Arelle/arelle
@paulwarren-wk
