### PR TITLE
Don't Process Non-iXBRL Models

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -21,7 +21,7 @@ from .constants import CONFIG_COPY_SCRIPT, CONFIG_FEATURE_PREFIX, CONFIG_LAUNCH_
     CONFIG_SCRIPT_URL, DEFAULT_COPY_SCRIPT, DEFAULT_LAUNCH_ON_LOAD, DEFAULT_OUTPUT_NAME, \
     DEFAULT_JS_FILENAME, DEFAULT_VIEWER_PATH, ERROR_MESSAGE_CODE, \
     EXCEPTION_MESSAGE_CODE, FEATURE_CONFIGS
-from .iXBRLViewer import IXBRLViewerBuilder, IXBRLViewerBuilderError
+from .iXBRLViewer import IXBRLViewerBuilder, IXBRLViewerBuilderError, isInlineDoc
 from .plugin import IXBRLViewerPluginData
 
 PLUGIN_NAME = 'ixbrl-viewer'
@@ -116,7 +116,8 @@ def resetPluginData(cntlr: Cntlr):
 
 def processModel(cntlr: Cntlr, modelXbrl: ModelXbrl):
     try:
-        pluginData(cntlr).builder.processModel(modelXbrl)
+        if isInlineDoc(modelXbrl.modelDocument):
+            pluginData(cntlr).builder.processModel(modelXbrl)
     except IXBRLViewerBuilderError as ex:
         print(ex)
     except Exception as ex:

--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -15,7 +15,7 @@ from copy import deepcopy
 from pathlib import Path
 
 from arelle import XbrlConst
-from arelle.ModelDocument import Type
+from arelle.ModelDocument import ModelDocument, Type
 from arelle.ModelRelationshipSet import ModelRelationshipSet
 from arelle.ModelValue import QName, INVALIDixVALUE
 from arelle.ModelXbrl import ModelXbrl
@@ -78,6 +78,9 @@ class NamespaceMap:
 
 class IXBRLViewerBuilderError(Exception):
     pass
+
+def isInlineDoc(doc: ModelDocument | None) -> bool:
+    return doc is not None and doc.type in {Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET}
 
 class IXBRLViewerBuilder:
 
@@ -402,10 +405,9 @@ class IXBRLViewerBuilder:
         self.currentTargetReport = self.newTargetReport(getattr(report, "ixdsTarget", None))
         softwareCredits = set()
         for document in report.urlDocs.values():
-            if document.type not in (Type.INLINEXBRL, Type.INLINEXBRLDOCUMENTSET):
-                continue
-            matches = document.creationSoftwareMatches(document.creationSoftwareComment)
-            softwareCredits.update(matches)
+            if isInlineDoc(document):
+                matches = document.creationSoftwareMatches(document.creationSoftwareComment)
+                softwareCredits.update(matches)
         if softwareCredits:
             self.currentTargetReport["softwareCredits"] = list(softwareCredits)
         for f in report.facts:


### PR DESCRIPTION
#### Reason for change
If the iXBRL plugin is enabled and a non-iXBRL report is loaded an exception is thrown.

```
[viewer:exception] Exception 'ModelFact' object has no attribute 'format' 
Traceback ['  File "/Applications/Arelle.app/Contents/MacOS/plugin/iXBRLViewerPlugin/__init__.py", line 119, in processModel\n    pluginData(cntlr).builder.processModel(modelXbrl)\n', '  File "/Applications/Arelle.app/Contents/MacOS/plugin/iXBRLViewerPlugin/iXBRLViewer.py", line 412, in processModel\n    self.addFact(report, f)\n', '  File "/Applications/Arelle.app/Contents/MacOS/plugin/iXBRLViewerPlugin/iXBRLViewer.py", line 282, in addFact\n    if f.format is not None:\n       ^^^^^^^^\n']
```

#### Description of change
Check that the report is iXBRL before processing.

#### Steps to Test
* Load non-iXBRL doc: `python arelleCmdLine.py --plugins ixbrl-viewer --save-viewer ixbrlviewer.html --file https://www.sec.gov/Archives/edgar/data/1445305/000144530515000045/0001445305-15-000045-xbrl.zip`
* Confirm no exceptions are thrown.
* Confirm log: `[viewer:error] No inline XBRL documents loaded. Skipping iXBRL Viewer generation.`

**review**:
@Arelle/arelle
@paulwarren-wk
