### PR TITLE
Update CI Env

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-14
           - ubuntu-24.04
           - windows-2022
         node-version:

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -21,7 +21,7 @@ jobs:
         node-version:
           - '18'
           - '20'
-          - '21'
+          - '22'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.1.7

--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - macos-12
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
         node-version:
           - '18'

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -4,14 +4,14 @@ on:
   workflow_call:
     inputs:
       node_version:
-        default: '20'
+        default: '22'
         description: 'Node version to use'
         required: false
         type: string
   workflow_dispatch:
     inputs:
       node_version:
-        default: '20'
+        default: '22'
         description: 'Node version to use'
         required: true
         type: string

--- a/.github/workflows/npm-package.yml
+++ b/.github/workflows/npm-package.yml
@@ -20,7 +20,7 @@ permissions: {}
 
 jobs:
   build-package:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout ixbrl-viewer
         uses: actions/checkout@v4.1.7
@@ -59,7 +59,7 @@ jobs:
     environment: release
     permissions:
       contents: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Install Node.js

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-14
           - ubuntu-24.04
           - windows-2022
         node-version:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - macos-12
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
         node-version:
           - '18'
@@ -42,6 +42,15 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install Dependencies
         run: npm ci
+      - name: Setup Chromium Sandbox
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          cd ~/.cache/puppeteer/chrome/linux-*/chrome-linux64
+          sudo chown root:root chrome_sandbox
+          sudo chmod 4755 chrome_sandbox
+          sudo cp -p chrome_sandbox /usr/local/sbin/chrome-devel-sandbox
+          echo "CHROME_DEVEL_SANDBOX=/usr/local/sbin/chrome-devel-sandbox" >> $GITHUB_ENV
       - name: Install Arelle
         run: pip install .[arelle]
       - name: Build viewer js

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -20,7 +20,7 @@ jobs:
         node-version:
           - '18'
           - '20'
-          - '21'
+          - '22'
         python-version:
           - '3.12'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -30,7 +30,7 @@ permissions: {}
 
 jobs:
   build-package:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout ixbrl-viewer
         uses: actions/checkout@v4.1.7
@@ -77,7 +77,7 @@ jobs:
     environment: release
     permissions:
       contents: write
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags')
     steps:
       - name: Install twine

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       node_version:
-        default: '20'
+        default: '22'
         description: 'Node version to use'
         required: false
         type: string
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       node_version:
-        default: '20'
+        default: '22'
         description: 'Node version to use'
         required: true
         type: string

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-14
           - ubuntu-24.04
           - windows-2022
         python-version:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os:
           - macos-12
-          - ubuntu-22.04
+          - ubuntu-24.04
           - windows-2022
         python-version:
           - '3.8'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
#### Reason for change
* macOS 14 and Ubuntu 24.04 runners were published this year.
* macOS 12 runner is scheduled for removal later this year.
* Node 22 LTS was released.
* Node 21 (non-LTS) is no longer maintained.

#### Description of change
* Update Ubuntu and macOS runners.
* Update Node versions used in CI.

#### Steps to Test
* [x] CI

**review**:
@Arelle/arelle
@paulwarren-wk
