### PR TITLE
Install and run twine in venv with pipx

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -80,8 +80,6 @@ jobs:
     runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags')
     steps:
-      - name: Install twine
-        run: pip install -U twine
       - name: Download source distribution artifact
         uses: actions/download-artifact@v4.1.8
         with:
@@ -95,7 +93,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_REPOSITORY: ${{ github.repository == 'Arelle/ixbrl-viewer' && 'pypi' || 'testpypi' }}
-        run: twine upload ./*
+        run: pipx run twine upload ./*
       - name: Upload release artifacts
         uses: softprops/action-gh-release@v2.0.8
         with:


### PR DESCRIPTION
#### Reason for change
Release workflow [is failing](https://github.com/Arelle/ixbrl-viewer/actions/runs/10708308211/job/29691632895) on twine install.
> Run pip install -U twine
> error: externally-managed-environment
>
> × This environment is externally managed
> ╰─> To install Python packages system-wide, try apt install
>     python3-xyz, where xyz is the package you are trying to
>     install.
>     
>     If you wish to install a non-Debian-packaged Python package,
>     create a virtual environment using python3 -m venv path/to/venv.
>     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
>     sure you have python3-full installed.
>     
>     If you wish to install a non-Debian packaged Python application,
>     it may be easiest to use pipx install xyz, which will manage a
>     virtual environment for you. Make sure you have pipx installed.
>     
>     See /usr/share/doc/python3.12/README.venv for more information.


#### Description of change
Install and run twine using pipx to automatically create a venv.

#### Steps to Test
* [x] create a workflow that runs twine using pipx to ensure it works from CI env (the modified job only runs on release).

**review**:
@Arelle/arelle
@paulwarren-wk
