### PR TITLE
Fix incorrect message shown for inconsistent calculations

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/calculationInspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/calculationInspector.js
@@ -179,7 +179,7 @@ export class CalculationInspector extends Dialog {
             messageCell.addClass("consistent").find(".message").text(i18next.t('factDetails.calculationIsConsistent'));
         }
         else {
-            messageCell.addClass("inconsistent").find(".message").text(i18next.t('factDetails.calculationIsConsistent'));
+            messageCell.addClass("inconsistent").find(".message").text(i18next.t('factDetails.calculationIsInconsistent'));
         }
     }
 }


### PR DESCRIPTION
#### Reason for change

The calculation inspector incorrectly states that inconsistent calculations are consistent.

![image](https://github.com/user-attachments/assets/03cba366-3633-4b8d-b231-e3d559d1fa40)

#### Description of change

Switch to using correct message.

#### Steps to Test

Find a document with an inconsistent calculation. Enable calc 1.1 calculation checking, open inspector for calculation and check message.

**review**:
@Arelle/arelle
@paulwarren-wk
