### PR TITLE
Fix links to calculation contributing items

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -769,7 +769,7 @@ export class Inspector {
                     itemHTML.addClass("calc-fact-link");
                     itemHTML.addClass("calc-fact-link");
                     itemHTML.data('ivids', r.facts.items().map(f => f.vuid));
-                    itemHTML.on("click", () => this.selectItem(r.facts.items[0].vuid));
+                    itemHTML.on("click", () => this.selectItem(r.facts.items()[0].vuid));
                     itemHTML.on("mouseenter", () => r.facts.items().forEach(f => this._viewer.linkedHighlightFact(f)));
                     itemHTML.on("mouseleave", () => r.facts.items().forEach(f => this._viewer.clearLinkedHighlightFact(f)));
                     r.facts.items().forEach(f => this._viewer.highlightRelatedFact(f));


### PR DESCRIPTION
#### Reason for change

Fixes regression with link to contributing items in a calculation.

Clicking on a contributing item in the calculations section of the fact inspector gives an exception:

> inspector.js:772 Uncaught TypeError: Cannot read properties of undefined (reading 'vuid')

#### Description of change

`items` changed from a property to a method, but this reference was not updated.

#### Steps to Test

Open a report with calculations. Click on the calculation total, then on one of the contributing items in the fact inspector.  The contributing item should now be selected.

**review**:
@Arelle/arelle
@paulwarren-wk
