### PR TITLE
Use correct calc1.1 arcrole

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -106,7 +106,7 @@ class IXBRLViewerBuilder:
         self.roleMap.getPrefix(XbrlConst.standardLabel, "std")
         self.roleMap.getPrefix(XbrlConst.documentationLabel, "doc")
         self.roleMap.getPrefix(XbrlConst.summationItem, "calc")
-        self.roleMap.getPrefix(XbrlConst.summationItem, "calc11")
+        self.roleMap.getPrefix(XbrlConst.summationItem11, "calc11")
         self.roleMap.getPrefix(XbrlConst.parentChild, "pres")
         self.roleMap.getPrefix(XbrlConst.dimensionDefault, "d-d")
         self.roleMap.getPrefix(WIDER_NARROWER_ARCROLE, "w-n")


### PR DESCRIPTION
#### Reason for change
Resolves [google group issue](https://groups.google.com/g/arelle-users/c/KzAvo0waE2I)

#### Description of change
The wrong constant was used from Arelle for calc 1.1.

#### Steps to Test
* Generate a viewer for [a report with calc 1.1 relationships](https://github.com/user-attachments/files/17166221/ex-2024-09-27-en.calc1.1.zip).
* Verify calc 1.1 relationships show up in the inspector.

**review**:
@Arelle/arelle
@paulwarren-wk
