### PR TITLE
Drop support for EOL Python 3.8

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,7 +19,6 @@ jobs:
           - ubuntu-24.04
           - windows-2022
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.8',
+    
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
@@ -27,7 +27,7 @@ classifiers = [
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: XML'
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     'lxml>=4,<6'
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 [tox]
-envlist = py38, py39, py310, py311, py312, lint, typing
+envlist = py39, py310, py311, py312, lint, typing
 isolated_build = True
 skip_missing_interpreters = False
 
 [gh-actions]
 python =
-  3.8: py38
   3.9: py39
   3.10: py310
   3.11: py311


### PR DESCRIPTION
#### Reason for change
Python 3.8 is EOL.

#### Description of change
* Drop Python 3.8 from CI testing.
* Drop Python 3.8 support from Python package.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
