### PR TITLE
Support -ix-hidden

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -205,7 +205,7 @@ export function localId(viewerUniqueId) {
 
 export function getIXHiddenLinkStyle(domNode) {
     if (domNode.hasAttribute('style')) {
-        const re = /(?:^|\s|;)-(?:sec|esef)-ix-hidden:\s*([^\s;]+)/;
+        const re = /(?:^|\s|;)(?:-sec|-esef)?-ix-hidden:\s*([^\s;]+)/;
         const m = domNode.getAttribute('style').match(re);
         if (m) {
             return m[1];

--- a/iXBRLViewerPlugin/viewer/src/js/util.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.test.js
@@ -147,6 +147,7 @@ describe("Regex escape", () => {
 
 describe("Get IX Hidden Link Style", () => {
     it.each([
+        ["-ix-hidden:123", "123"],
         ["-sec-ix-hidden:123", "123"],
         ["-esef-ix-hidden:123", "123"],
         ["-xxx-ix-hidden:123", null],


### PR DESCRIPTION
#### Reason for change
A [Hidden Fact CSS link](https://www.xbrl.org/WGN/html-for-ixbrl-wgn/WGN-2024-11-05/html-for-ixbrl-wgn-2024-11-05.html#sec-hidden-fact-css-link) section was added to Designing HTML for Inline XBRL 1.0 that recommends `-ix-hidden`.

#### Description of change
Update the regex and tests.

#### Steps to Test

**review**:
@Arelle/arelle
@paulwarren-wk
