### PR TITLE
Migrate lang attributes to iframe documents and remove default

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/cy/translation.json
@@ -146,10 +146,10 @@
   "menu": {
     "actions": "Gweithredoedd",
     "applicationLanguage": "Iaith Cais",
+    "contactUs": "Cysylltwch â Ni",
     "documentLanguage": "Iaith Dogfen",
     "help": "Cymorth",
     "options": "Opsiynau",
-    "contactUs": "Cysylltwch â Ni",
     "survey": "Arolwg",
     "userGuide": "Canllaw Defnyddiwr"
   },

--- a/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/en/translation.json
@@ -146,10 +146,10 @@
   "menu": {
     "actions": "Actions",
     "applicationLanguage": "Application Language",
+    "contactUs": "Contact Us",
     "documentLanguage": "Document Language",
     "help": "Help",
     "options": "Options",
-    "contactUs": "Contact Us",
     "survey": "Survey",
     "userGuide": "User Guide"
   },

--- a/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
+++ b/iXBRLViewerPlugin/viewer/src/i18n/es/translation.json
@@ -146,10 +146,10 @@
   "menu": {
     "actions": "Comportamientos",
     "applicationLanguage": "Idioma de Aplicación",
+    "contactUs": "Contacta con nosotros",
     "documentLanguage": "Idioma del Documento",
     "help": "Ayuda",
     "options": "Opciones",
-    "contactUs": "Contacta con nosotros",
     "survey": "Encuesta",
     "userGuide": "Guía del Usuario"
   },

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -429,6 +429,7 @@ export class Inspector {
 
     rebuildViewer() {
         $("#ixv").localize();
+        $('html').attr('lang', i18next.resolvedLanguage);
         this.buildDisplayOptionsMenu();
         this.buildHomeLink()
         this.buildToolbarHighlightMenu();

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -202,8 +202,8 @@ export class iXBRLViewer {
         doc.close();
 
         let docTitle = $('title').text();
-        if (docTitle != "") {
-            docTitle = "Inline Viewer - " + docTitle;
+        if (docTitle !== "") {
+            docTitle = `Inline Viewer - ${docTitle}`;
         }
         else {
             docTitle = "Inline Viewer";
@@ -237,7 +237,7 @@ export class iXBRLViewer {
     _getTaxonomyData() {
         for (let i = document.body.children.length - 1; i >= 0; i--) {
             const elt = document.body.children[i];
-            if (elt.tagName.toUpperCase() == 'SCRIPT' && elt.getAttribute("type") == 'application/x.ixbrl-viewer+json') {
+            if (elt.tagName.toUpperCase() === 'SCRIPT' && elt.getAttribute("type") === 'application/x.ixbrl-viewer+json') {
                 return elt.innerHTML;
             }
         }
@@ -245,7 +245,7 @@ export class iXBRLViewer {
     }
 
     _checkDocumentSetBrowserSupport() {
-        if (document.location.protocol == 'file:') {
+        if (document.location.protocol === 'file:') {
             alert("Displaying iXBRL document sets from local files is not supported.  Please view the viewer files using a web server.");
         }
     }
@@ -258,11 +258,11 @@ export class iXBRLViewer {
             else {
                 fetch(this.options.configUrl)
                     .then((resp) => {
-                        if (resp.status == 404) {
+                        if (resp.status === 404) {
                             return Promise.resolve({});
                         }
-                        else if (resp.status != 200) {
-                            return Promise.reject("Fetch failed: " + resp.status);
+                        if (resp.status !== 200) {
+                            return Promise.reject(`Fetch failed: ${resp.status}`);
                         }
                         return resp.json();
                     })
@@ -300,7 +300,7 @@ export class iXBRLViewer {
             // We need to parse JSON first so that we can determine feature enablement before loading begins.
             const taxonomyData = iv._getTaxonomyData();
             const parsedTaxonomyData = taxonomyData && JSON.parse(taxonomyData);
-            let features = parsedTaxonomyData && parsedTaxonomyData["features"];
+            let features = parsedTaxonomyData?.features;
             if (!features) {
                 features = {};
             }
@@ -349,19 +349,19 @@ export class iXBRLViewer {
             const progress = stubViewer ? 'Loading iXBRL Report' : 'Loading iXBRL Viewer';
             iv.setProgress(progress).then(() => {
                 /* Poll for iframe load completing - there doesn't seem to be a reliable event that we can use */
-                let timer = setInterval(function () {
+                const timer = setInterval(() => {
                     let complete = true;
-                    iframes.each(function (n) {
-                        const iframe = this;
+                    iframes.each((n, iframe) => {
                         const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
-                        if ((iframeDoc.readyState != 'complete' && iframeDoc.readyState != 'interactive') || $(iframe).contents().find("body").children().length == 0) {
+                        if ((iframeDoc.readyState !== 'complete' && iframeDoc.readyState !== 'interactive') || $(iframe).contents().find("body").children().length === 0) {
                             complete = false;
                         }
                     });
                     if (complete) {
                         clearInterval(timer);
 
-                        const viewer = iv.viewer = new Viewer(iv, iframes, reportSet);
+                        const viewer = new Viewer(iv, iframes, reportSet);
+                        iv.viewer = viewer
 
                         viewer.initialize()
                             .then(() => inspector.initialize(reportSet, viewer))
@@ -382,8 +382,8 @@ export class iXBRLViewer {
                                 .on('resizemove', (event) => {
                                     const target = event.target;
                                     const w = 100 * event.rect.width / $(target).parent().width();
-                                    target.style.width = w + '%';
-                                    $('#inspector').css('width', (100 - w) + '%');
+                                    target.style.width = `${w}%`;
+                                    $('#inspector').css('width', `${100 - w}%`);
                                 })
                                 .on('resizeend', (event) =>
                                     $('#ixv').css("pointer-events", "auto")
@@ -421,7 +421,7 @@ export class iXBRLViewer {
              * message up before the ensuing thread-blocking work
              * https://bugs.chromium.org/p/chromium/issues/detail?id=675795 
              */
-            window.requestAnimationFrame(function () {
+            window.requestAnimationFrame(() => {
                 console.log(`%c [Progress] ${msg} `, 'background: #77d1c8; color: black;');
                 $('#ixv .loader .text').text(msg);
                 window.requestAnimationFrame(() => resolve());

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -360,6 +360,19 @@ export class iXBRLViewer {
                     if (complete) {
                         clearInterval(timer);
 
+                        iframes.each((n, iframe) => {
+                            const htmlNode = $(iframe).contents().find('html');
+                            // A schema valid report should not have a lang attribute on the html element.
+                            // However, if the report is not schema valid, we shouldn't override it.
+                            if (htmlNode.attr('lang') === undefined) {
+                                // If the report has an XML lang attribute, use it as the HTML lang for screen readers.
+                                // If the language of the report can't be detected, set it to an empty string to avoid
+                                // inheriting the lang of the application HTML node (which is set to the UI language).
+                                const docLang = htmlNode.attr('xml:lang') || '';
+                                htmlNode.attr('lang', docLang);
+                            }
+                        });
+
                         const viewer = new Viewer(iv, iframes, reportSet);
                         iv.viewer = viewer
 

--- a/iXBRLViewerPlugin/viewer/src/js/theme.js
+++ b/iXBRLViewerPlugin/viewer/src/js/theme.js
@@ -1,9 +1,10 @@
 // See COPYRIGHT.md for copyright information
 
-import { STORAGE_THEME } from "./util";
+import { IXBRL_VIEWER_DATASET_PREFIX, STORAGE_THEME } from "./util";
 
 const DARK_THEME = 'dark';
 const LIGHT_THEME = 'light';
+const APP_THEME_DATASET_NAME = `${IXBRL_VIEWER_DATASET_PREFIX}Theme`;
 
 function getHtmlElement() {
     return document.querySelector('html');
@@ -16,7 +17,7 @@ export function getVariable(name) {
 
 function setTheme(theme) {
     const html = getHtmlElement();
-    html.dataset.theme = `theme-${theme}`;
+    html.dataset[APP_THEME_DATASET_NAME] = `theme-${theme}`;
 }
 
 function getStoredTheme() {
@@ -29,7 +30,7 @@ function storeTheme(theme) {
 
 export function getTheme() {
     const html = getHtmlElement();
-    return html.dataset.theme.replace('theme-','');
+    return html.dataset[APP_THEME_DATASET_NAME].replace('theme-','');
 }
 
 export function initializeTheme() {

--- a/iXBRLViewerPlugin/viewer/src/js/theme.js
+++ b/iXBRLViewerPlugin/viewer/src/js/theme.js
@@ -17,7 +17,7 @@ export function getVariable(name) {
 
 function setTheme(theme) {
     const html = getHtmlElement();
-    html.dataset[APP_THEME_DATASET_NAME] = `theme-${theme}`;
+    html.dataset[APP_THEME_DATASET_NAME] = theme;
 }
 
 function getStoredTheme() {
@@ -30,7 +30,7 @@ function storeTheme(theme) {
 
 export function getTheme() {
     const html = getHtmlElement();
-    return html.dataset[APP_THEME_DATASET_NAME].replace('theme-','');
+    return html.dataset[APP_THEME_DATASET_NAME];
 }
 
 export function initializeTheme() {

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -26,6 +26,8 @@ export const FEATURE_SURVEY_LINK = 'survey_link';
 export const FEATURE_SEARCH_ON_STARTUP = 'search_on_startup';
 export const FEATURE_HIGHLIGHT_FACTS_ON_STARTUP = 'highlight_facts_on_startup';
 
+export const IXBRL_VIEWER_DATASET_PREFIX = 'ixbrlViewer';
+
 export const STORAGE_APP_LANGUAGE = "ixbrl-viewer-app-language";
 export const STORAGE_THEME = "ixbrl-viewer-theme";
 export const STORAGE_HIGHLIGHT_FACTS = "ixbrl-viewer-highlight-all-facts";

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -234,3 +234,21 @@ export function getIXHiddenLinkStyle(domNode) {
     }
     return null;
 }
+
+/**
+ * Moves all attributes from one element to another, excluding data attributes created by the viewer application.
+ */
+export function moveNonAppAttributes(fromElement, toElement) {
+    for (const attr of [...fromElement.attributes]) {
+        if (!attr.name.startsWith("data-")) {
+            toElement.setAttribute(attr.name, attr.value); 
+            fromElement.removeAttribute(attr.name);
+        }
+    }
+    for (const [key, value] of Object.entries(fromElement.dataset)) {
+        if (!key.startsWith(IXBRL_VIEWER_DATASET_PREFIX)) {
+            toElement.dataset[key] = value;
+            delete fromElement.dataset[key];
+        }
+    }
+}

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -55,7 +55,7 @@
   }
 }
 
-:root[data-ixbrl-viewer-theme="theme-dark"] {
+:root[data-ixbrl-viewer-theme="dark"] {
   --colour-bg-selected: @colour-bg-selected-d;
   --colour-bg-tag: @colour-bg-tag-d;
   --colour-bg: @colour-bg-d;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -55,7 +55,7 @@
   }
 }
 
-:root[data-theme="theme-dark"] {
+:root[data-ixbrl-viewer-theme="theme-dark"] {
   --colour-bg-selected: @colour-bg-selected-d;
   --colour-bg-tag: @colour-bg-tag-d;
   --colour-bg: @colour-bg-d;


### PR DESCRIPTION
#### Reason for change
Reopening #684. The previous discussion moved into changing the application language. That feature is being handled by another effort.

#### Description of change
We currently set the lang attribute to a default of en-US for all non stub viewers.

#### Steps to Test
* Use [a report with a non English xml:lang value](https://github.com/Arelle/ixbrl-viewer/files/15476117/austin-2024-05-28-fr.zip).
* Verify that the lang attribute on the root HTML node reflects the application UI language and is updated when you change it.
* Verify that for the non-stub viewer, that all attributes of the report document are migrated to the iframe HTML node for the report document.
* Verify that that the lang attribute on the report document iframe HTML nodes reflects the xml:lang attribute from the filing.

**review**:
@Arelle/arelle
@paulwarren-wk
