### PR TITLE
Remove read contents permissions

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -7,8 +7,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   tests:

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -6,8 +6,7 @@ on:
       - master
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   tests:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,8 +7,7 @@ on:
   workflow_call:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   tests:


### PR DESCRIPTION
#### Reason for change
Release workflow is failing because it doesn't have contents permissions and it calls the test workflows which require it. The read permissions are not needed for workflows in open-source repo.

#### Description of change
Remove read permissions from the test workflows.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
