### PR TITLE
Use preferred prefixes in summary tag counts

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -804,7 +804,7 @@ export class Inspector {
         const sortedPrefixCounts = [...tagCounts.entries()].sort((a, b) => a[0].localeCompare(b[0]));
         for (const [prefix, counts] of sortedPrefixCounts) {
             const countRow = $("<tr></tr>").appendTo(summaryTagsTableBody);
-            countRow.append($("<th></th>").attr("scope", "row").text(prefix));
+            countRow.append($("<th></th>").attr("scope", "row").text(this._reportSet.preferredPrefix(prefix)));
             insertTagCount(countRow, counts[PRIMARY_ITEMS_KEY], totalPrimaryItemTags);
             insertTagCount(countRow, counts[DIMENSIONS_KEY], totalDimensionTags);
             insertTagCount(countRow, counts[MEMBERS_KEY], totalMemberTags);


### PR DESCRIPTION
#### Reason for change

Bug - preferred prefixes not used consistently:

![image](https://github.com/user-attachments/assets/3bd3ca2f-c3d2-4e3b-bdd0-7281ac46d79b)

#### Steps to Test

Open UK document that uses "nsN" style prefixes, and confirm that the document summary page now uses the preferred `uk-` prefixes.

**review**:
@Arelle/arelle
@paulwarren-wk
