### PR TITLE
Remove default logo if home link feature is set

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -334,6 +334,7 @@ export class Inspector {
         if (!this._iv.isStaticFeatureEnabled(FEATURE_HOME_LINK_URL)) {
             return;
         }
+        $("#top-bar img.header").remove();
         let homeLinkUrl = this._iv.getStaticFeatureValue(FEATURE_HOME_LINK_URL);
         let homeLinkText;
         if (this._iv.isStaticFeatureEnabled(FEATURE_HOME_LINK_LABEL)) {

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -232,6 +232,7 @@
       font-size: 2.2rem;
       font-weight: bold;
       margin-left: 1rem;
+      margin-right: 1rem;
     }
 
     .header {


### PR DESCRIPTION
#### Reason for change

Combination of home link and default logo clutters the top bar.  The home link should replace the logo, if enabled.

#### Steps to Test

Deploy viewer with this `ixbrlviewer.config.json` config:

```json
{
  "features": {
          "home_link_url": "https://www.arelle.org",
          "home_link_text": "My Viewer"
  }
}
```

**review**:
@Arelle/arelle
@paulwarren-wk
