### PR TITLE
Fix GUI Save Viewer Exception

### DIFF
--- a/iXBRLViewerPlugin/__init__.py
+++ b/iXBRLViewerPlugin/__init__.py
@@ -241,6 +241,12 @@ def iXBRLViewerSaveCommand(cntlr):
         return
     dialog = SaveViewerDialog(cntlr)
     dialog.render()
+    features = {
+        feature: True
+        for feature in dialog.features()
+    }
+    pluginData(cntlr).builder = IXBRLViewerBuilder(cntlr, features=features)
+    processModel(cntlr, modelXbrl)
     if dialog.accepted and dialog.filename():
         generateViewer(
             cntlr=cntlr,
@@ -248,7 +254,6 @@ def iXBRLViewerSaveCommand(cntlr):
             viewerURL=dialog.scriptUrl(),
             copyScript=dialog.copyScript(),
             zipViewerOutput=dialog.zipViewerOutput(),
-            features=dialog.features(),
         )
 
 

--- a/iXBRLViewerPlugin/constants.py
+++ b/iXBRLViewerPlugin/constants.py
@@ -80,20 +80,20 @@ FEATURE_CONFIGS = [
     FeatureConfig(
         key='search_on_startup',
         label='Search on startup',
-        description='Show the search pane by default on startup',
+        description='Show the search pane by default on startup.',
         cliAction='store_true',
         cliDefault=None,
-        guiVisible=False,
-        guiDefault=None
+        guiVisible=True,
+        guiDefault=False
     ),
     FeatureConfig(
         key='highlight_facts_on_startup',
         label='Highlight facts on startup',
-        description='Default "Highlight all facts" to on',
+        description='Default "Highlight all facts" to on.',
         cliAction='store_true',
         cliDefault=None,
-        guiVisible=False,
-        guiDefault=None
+        guiVisible=True,
+        guiDefault=False
     )
 ]
 GUI_FEATURE_CONFIGS = [c for c in FEATURE_CONFIGS if c.guiVisible]


### PR DESCRIPTION
#### Reason for change
Resolves exception [reported to Arelle users google group](https://groups.google.com/g/arelle-users/c/OrpdWDq_uvw). The save menu wasn't updated when the viewer was updated to use the plugin data pattern.
<img width="455" alt="TypeError" src="https://github.com/user-attachments/assets/94f4c74f-a827-4e41-8393-d381c6bf607c">

Also adds the new highlight_facts_on_startup and search_on_startup options options to the GUI settings menu.
<img width="501" alt="Screenshot 2024-12-04 at 11 18 54 AM" src="https://github.com/user-attachments/assets/c717a2e4-0bb5-4a91-aa3b-bfed121c3c53">

#### Description of change
* Update save menu code to use plugin data.
* Enable new features in GUI.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
