### PR TITLE
Improve Accessibility of Highlight Colors

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/colours-dark-mode.less
+++ b/iXBRLViewerPlugin/viewer/src/less/colours-dark-mode.less
@@ -22,9 +22,9 @@
 
 @colour-border-grey-d: darken(@colour-foreground-d, 59.7);
 
-@colour-highlight-default-d: lighten(desaturate(spin(@colour-secondary-d, -0.5660), 31.1688), 44.9020); // #d9f3be
-@colour-highlight-1-d: lighten(saturate(spin(@colour-tertiary-d, -25.3918), 17.2043), 46.4706); // #eaa8ff
-@colour-highlight-2-d: lighten(saturate(spin(@colour-warning-d, 1.0810), 17.7215), 38.6275); // #fff0b3
+@colour-highlight-default-d: lighten(desaturate(spin(@colour-secondary-d, -0.5660), 31.1688), 34); // #beea8f
+@colour-highlight-1-d: lighten(saturate(spin(@colour-tertiary-d, -25.3918), 17.2043), 36); // #dd73ff
+@colour-highlight-2-d: lighten(saturate(spin(@colour-warning-d, 1.0810), 17.7215), 33); // #ffac29
 
 @colour-icon-grey-d: @colour-text-d;
 

--- a/iXBRLViewerPlugin/viewer/src/less/colours.less
+++ b/iXBRLViewerPlugin/viewer/src/less/colours.less
@@ -22,9 +22,9 @@
 
 @colour-border-grey: lighten(@colour-foreground, 79.6078);
 
-@colour-highlight-default: lighten(desaturate(spin(@colour-secondary, -0.5660), 31.1688), 44.9020); // #d9f3be
-@colour-highlight-1: lighten(saturate(spin(@colour-tertiary, -25.3918), 17.2043), 46.4706); // #eaa8ff
-@colour-highlight-2: lighten(saturate(spin(@colour-warning, 1.0810), 17.7215), 38.6275); // #ffb746
+@colour-highlight-default: lighten(desaturate(spin(@colour-secondary, -0.5660), 31.1688), 34); // #beea8f
+@colour-highlight-1: lighten(saturate(spin(@colour-tertiary, -25.3918), 17.2043), 36); // #dd73ff
+@colour-highlight-2: lighten(saturate(spin(@colour-warning, 1.0810), 17.7215), 33); // #ffac29
 
 @colour-icon-grey: @colour-text;
 

--- a/tests/puppeteer/framework/page_objects/doc_frame.js
+++ b/tests/puppeteer/framework/page_objects/doc_frame.js
@@ -46,10 +46,10 @@ export class DocFrame {
 export class Highlight {
 
     static darkBlue = 'rgb(2, 109, 206)';
-    static green = 'rgb(217, 243, 190)';
+    static green = 'rgb(190, 234, 143)';
     static lightBlue = 'rgb(0, 148, 255)';
-    static yellow = 'rgb(255, 183, 70)';
-    static purple = 'rgb(234, 168, 255)';
+    static yellow = 'rgb(255, 172, 41)';
+    static purple = 'rgb(221, 115, 255)';
     static propBgColor = 'background-color';
     static propOutline = 'outline';
     static transparent = 'rgba(0, 0, 0, 0)';


### PR DESCRIPTION
#### Reason for change
Highlight colors couldn't be distinguished by color blind users. This can be tested with [Colorblindly](https://github.com/oftheheadland/Colorblindly).

Before:
<img width="400" alt="Screenshot 2024-12-05 at 6 28 27 PM" src="https://github.com/user-attachments/assets/7e870c96-642e-4902-934e-aa9c5a325699"> <img width="400" alt="Screenshot 2024-12-05 at 6 28 33 PM" src="https://github.com/user-attachments/assets/65e76515-a53e-4178-a549-c9e18476bc20">

After:
<img width="400" alt="Screenshot 2024-12-05 at 6 33 25 PM" src="https://github.com/user-attachments/assets/397ac5ce-b02a-4a33-b1ae-d4839d980993"> <img width="400" alt="Screenshot 2024-12-05 at 6 33 22 PM" src="https://github.com/user-attachments/assets/7218812b-fd89-46d2-a8f0-c6d850d7775a">


#### Description of change
Modified colors for accessibility.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
