### PR TITLE
Persist User Theme Selection in Local Storage

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/theme.js
+++ b/iXBRLViewerPlugin/viewer/src/js/theme.js
@@ -1,18 +1,30 @@
 // See COPYRIGHT.md for copyright information
 
+import { STORAGE_THEME } from "./util";
+
+const DARK_THEME = 'dark';
+const LIGHT_THEME = 'light';
+
 function getHtmlElement() {
     return document.querySelector('html');
 }
 
 export function getVariable(name) {
     const html = getHtmlElement();
-    return getComputedStyle(html).getPropertyValue(name);s
+    return getComputedStyle(html).getPropertyValue(name);
 }
 
 function setTheme(theme) {
     const html = getHtmlElement();
     html.dataset.theme = `theme-${theme}`;
-    console.log('Set theme:', theme);
+}
+
+function getStoredTheme() {
+    return localStorage.getItem(STORAGE_THEME);
+}
+
+function storeTheme(theme) {
+    localStorage.setItem(STORAGE_THEME, theme);
 }
 
 export function getTheme() {
@@ -21,16 +33,17 @@ export function getTheme() {
 }
 
 export function initializeTheme() {
-    const initialTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
-            ? 'dark'
-            : 'light';
-    setTheme(initialTheme);
+    const storedTheme = getStoredTheme();
+    if (storedTheme !== null) {
+        setTheme(storedTheme);
+    } else {
+        setTheme(window.matchMedia(`(prefers-color-scheme: ${DARK_THEME})`).matches ? DARK_THEME : LIGHT_THEME);
+    }
 }
 
 export function toggleTheme() {
-    if (getTheme() === 'light') {
-        setTheme('dark');
-    } else {
-        setTheme('light');
-    }
+    const currentTheme = getTheme();
+    const newTheme = currentTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
+    setTheme(newTheme);
+    storeTheme(newTheme);
 }

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -26,6 +26,7 @@ export const FEATURE_SURVEY_LINK = 'survey_link';
 export const FEATURE_SEARCH_ON_STARTUP = 'search_on_startup';
 export const FEATURE_HIGHLIGHT_FACTS_ON_STARTUP = 'highlight_facts_on_startup';
 
+export const STORAGE_THEME = "ixbrl-viewer-theme";
 export const STORAGE_HIGHLIGHT_FACTS = "ixbrl-viewer-highlight-all-facts";
 export const STORAGE_HOME_LINK_QUERY = "ixbrl-viewer-home-link-query";
 


### PR DESCRIPTION
#### Reason for change
We allow users to toggle between light and dark mode, but their choice is reset on refresh or when a different viewer is opened.

#### Description of change
* If a user explicitly changes the theme we record their choice in local storage.
* At startup we check if a choice from a previous session is in local storage. If there is, we use it.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
