### PR TITLE
Prefer visible facts in default search results

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/search.js
+++ b/iXBRLViewerPlugin/viewer/src/js/search.js
@@ -13,42 +13,49 @@ export class ReportSearch {
         var dims = {};
         var facts = this._reportSet.facts();
         this.periods = {};
-        for (var i = 0; i < facts.length; i++) {
-            var f = facts[i];
-            var doc = { "id": f.vuid };
-            var l = f.getLabel("std");
-            doc.concept = f.conceptQName().localname;
-            doc.doc = f.getLabel("doc");
-            doc.date = f.periodTo();
-            doc.startDate = f.periodFrom();
-            var dims = f.dimensions();
-            for (var d in dims) {
-                if (f.report.getConcept(d).isTypedDimension()) {
-                    if (dims[d] !== null) {
-                        l += " " + dims[d];
+        // Add hidden facts to index later, so that they appear later in the
+        // default search
+        for (const hidden of [false, true]) {
+            for (var i = 0; i < facts.length; i++) {
+                var f = facts[i];
+                if (f.isHidden() !== hidden) {
+                    continue;
+                }
+                var doc = { "id": f.vuid };
+                var l = f.getLabel("std");
+                doc.concept = f.conceptQName().localname;
+                doc.doc = f.getLabel("doc");
+                doc.date = f.periodTo();
+                doc.startDate = f.periodFrom();
+                var dims = f.dimensions();
+                for (var d in dims) {
+                    if (f.report.getConcept(d).isTypedDimension()) {
+                        if (dims[d] !== null) {
+                            l += " " + dims[d];
+                        }
+                    }
+                    else {
+                        l += " " + f.report.getLabel(dims[d], "std");
                     }
                 }
-                else {
-                    l += " " + f.report.getLabel(dims[d], "std");
+                doc.label = l;
+                doc.ref = f.concept().referenceValuesAsString();
+                const wider = f.widerConcepts();
+                if (wider.length > 0) {
+                    doc.widerConcept = f.report.qname(wider[0]).localname;
+                    doc.widerLabel = f.report.getLabel(wider[0], "std");
+                    doc.widerDoc = f.report.getLabel(wider[0], "doc");
                 }
-            }
-            doc.label = l;
-            doc.ref = f.concept().referenceValuesAsString();
-            const wider = f.widerConcepts();
-            if (wider.length > 0) {
-                doc.widerConcept = f.report.qname(wider[0]).localname;
-                doc.widerLabel = f.report.getLabel(wider[0], "std");
-                doc.widerDoc = f.report.getLabel(wider[0], "doc");
-            }
-            docs.push(doc);
+                docs.push(doc);
 
-            var p = f.period();
-            if (p) {
-                this.periods[p.key()] = p.toString();
-            }
+                var p = f.period();
+                if (p) {
+                    this.periods[p.key()] = p.toString();
+                }
 
-            if (i % 100 === 0) {
-                yield;
+                if (i % 100 === 0) {
+                    yield;
+                }
             }
         }
         const builder = new lunr.Builder();

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -65,7 +65,7 @@ export class Viewer {
                     viewer._iframes.each(function (docIndex) { 
                         $(this).data("selected", docIndex == viewer._currentDocumentIndex);
                         const reportIndex = $(this).data("report-index");
-                        viewer._preProcessiXBRL($(this).contents().find("body").get(0), reportIndex, docIndex);
+                        viewer._preProcessiXBRL($(this).contents().find("body").get(0), reportIndex, docIndex, false);
                     });
 
                     /* Call plugin promise for each document in turn */


### PR DESCRIPTION
#### Reason for change

Requested by FRC.

#### Description of change

The default search (empty search string) just returns all results in the order that they were added to the index. This change populates the index in two passes, adding visible facts first, then hidden facts.

#### Steps to Test

Open any document with a mix of hidden and non-hidden facts. Switch to search pane.  Confirm that hidden facts appear last.

**review**:
@Arelle/arelle
@paulwarren-wk
