### PR TITLE
Hide calculation mode option if document has no calculations

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -305,7 +305,10 @@ export class Inspector {
 
             // Options
             this._optionsMenu.addLabel(i18next.t("menu.options"));
-            this._optionsMenu.addCheckboxItem(i18next.t("calculation.useCalculations11"), (useCalc11) => this.setCalculationMode(useCalc11), "calculation-mode", "select-language", this._useCalc11);
+
+            if (this._reportSet.usesCalculations()) {
+                this._optionsMenu.addCheckboxItem(i18next.t("calculation.useCalculations11"), (useCalc11) => this.setCalculationMode(useCalc11), "calculation-mode", "select-language", this._useCalc11);
+            }
         }
         let helpLinks = {}
         let guideLinkUrl = this._iv.getGuideLinkUrl();

--- a/iXBRLViewerPlugin/viewer/src/js/reportset.js
+++ b/iXBRLViewerPlugin/viewer/src/js/reportset.js
@@ -246,6 +246,10 @@ export class ReportSet {
         return this.reportsData().some(r => r.rels?.["w-n"] !== undefined);
     }
 
+    usesCalculations() {
+        return this.reportsData().some(r => Object.keys(r.rels?.calc ?? {}).length > 0);
+    }
+
     hasValidationErrors() {
         return this._data.validation !== undefined && this._data.validation.length > 0;
     }


### PR DESCRIPTION
#### Reason for change

The option for Calculations 1.1 is a bit confusing to the uninitiated, particularly if the report has no calculations at all.

#### Description of change

Calculations 1.1 option is hidden if the document contains no calculation relationships.

#### Steps to Test

Confirm that option is present for documents with calculations (e.g. ESEF/SEC) and absent on those without (e.g. CH).

**review**:
@Arelle/arelle
@paulwarren-wk
