### PR TITLE
Add missing closing tag - fix XHTML validity

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -503,7 +503,7 @@ export class Inspector {
             .appendTo(row);
         const dt = f.concept().dataType();
         if (dt !== undefined) {
-           $('<div class="datatype">')
+           $('<div class="datatype"></div>')
             .text(dt.label())
             .appendTo(row);
         }


### PR DESCRIPTION
#### Reason for change

https://github.com/Arelle/ixbrl-viewer/issues/786

#### Description of change

Adds missing closing tag.

#### Steps to Test

Create a viewer with a `.xhtml` extension, and confirm that the search page now works. Previously you would see an incomplete search pane, with an error on the console:

![image](https://github.com/user-attachments/assets/d246deaf-b172-443e-bbfb-d301210e22fb)


**review**:
@Arelle/arelle
@paulwarren-wk
