### PR TITLE
Fix inspector resize

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -129,7 +129,7 @@
     left: 0;
     top: var(--top-bar-height);
     bottom: 0;
-    z-index: 0;
+    z-index: 1;
     display: flex;
     flex-flow: column;
 


### PR DESCRIPTION
#### Reason for change

Regression  - no longer possible to resize the fact inspector by dragging the border between the inspector and viewer panes.

#### Description of change

Increase the `z-order` of the viewer pane. The resize relies on an invisible HTML element that overlaps the inspector pane by a few pixels. The regression occurred in e452daaf6a48cd8ac6af0e89b6b70cddca1f53ae which swapped the order of the viewer and inspector panes to make the tab order more intuitive. Unfortunately, this meant that overlapping element was now under the inspector pane and thus inaccessible. 

#### Steps to Test

Confirm that the pane can now be resized.

**review**:
@Arelle/arelle
@paulwarren-wk
