### PR TITLE
Store the latest copy of XML documents for serialisation

### DIFF
--- a/iXBRLViewerPlugin/iXBRLViewer.py
+++ b/iXBRLViewerPlugin/iXBRLViewer.py
@@ -561,20 +561,22 @@ class iXBRLViewer:
 
     def __init__(self, cntlr: Cntlr):
         self.reportZip = None
-        self.files = []
+        self.filesByFilename = dict()
         self.filingDocuments = None
         self.cntlr = cntlr
-        self.filenames = set()
         self.assets = []
 
     def addReportAssets(self, assets):
         self.assets.extend(assets)
 
     def addFile(self, ivf):
-        if ivf.filename in self.filenames:
-            return
-        self.files.append(ivf)
-        self.filenames.add(ivf.filename)
+        # Overwrite previous occurrences of the same document, because it may
+        # have had more IDs added to it by subsequent target documents.
+        self.filesByFilename[ivf.filename] = ivf
+
+    @property
+    def files(self):
+        return list(self.filesByFilename.values())
 
     def addFilingDoc(self, filingDocuments):
         self.filingDocuments = filingDocuments

--- a/tests/puppeteer/framework/page_objects/fact_details_panel.js
+++ b/tests/puppeteer/framework/page_objects/fact_details_panel.js
@@ -29,7 +29,7 @@ export class FactDetailsPanel {
                 'Duplicate Count');
         this.factValue = new Text(
                 this.#viewerPage,
-                '//*[@data-i18n="factDetails.factValue"]//ancestor::tr//*[contains(@class, "value")]',
+                '//*[@data-i18n="factDetails.factValue"]//ancestor::tr//*[contains(concat(" ",@class," "), " value ")]',
                 'Fact Value');
         this.entity = new Text(
                 this.#viewerPage,


### PR DESCRIPTION
#### Reason for change

Fixes #793 

#### Description of change

When adding facts to the viewer, we add an ID attribute if there isn't one already, modifying the original XML model. After processing each target document, we add a copy of the associated XML document to the viewer for serialisation. Previously, if the same document got added twice, we ignored the second one, meaning that any IDs added by the second target got lost. This PR changes this behaviour to take the latest document, which will have IDs added by all targets.

#### Steps to Test

Test viewer generation with a document containing multiple target documents, and at least some facts in each document with no ID attributes. Go to search, and confirm that with no filters the number of facts shown matches the total number of facts. Confirm that filtering to each target returns the correct numbers of facts. 

[This filing](https://filings.xbrl.org/filing/213800GE3FA4C52C1N05-2024-09-30-ESEF-GB-0) exhibits the problem.

Note that this problem affects viewer generation, so filings exhibiting this problem will need to be regenerated.

**review**:
@Arelle/arelle
@paulwarren-wk
