### PR TITLE
Tolerate missing dimension definitions when generating document summary.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/concept.js
+++ b/iXBRLViewerPlugin/viewer/src/js/concept.js
@@ -5,7 +5,9 @@ import { Balance } from "./balance.js";
 
 export class Concept {
     constructor(report, name) {
-        this._c = report.concepts()[name] || {};
+        const c = report.concepts()[name];
+        this.hasDefinition = (c !== undefined);
+        this._c = c ?? {};
         this.name = name;
         this.report = report;
     }

--- a/iXBRLViewerPlugin/viewer/src/js/summary.js
+++ b/iXBRLViewerPlugin/viewer/src/js/summary.js
@@ -94,13 +94,17 @@ export class DocumentSummary {
                 counter.addDimension(dimension);
 
                 const dimensionConcept = fact.report.getConcept(dimension);
-                if (dimensionConcept.isTypedDimension()) {
+                if (!dimensionConcept.hasDefinition) {
+                    console.log("Missing definition for dimension: " + dimension);
+                }
+                else if (dimensionConcept.isTypedDimension()) {
                     const typedDomainElement = dimensionConcept.typedDomainElement();
                     if (typedDomainElement) {
                         counter = this._getTagCounter(tagCounts, typedDomainElement);
                         counter.addMember(typedDomainElement);
                     }
-                } else {
+                } 
+                else {
                     counter = this._getTagCounter(tagCounts, member);
                     counter.addMember(member);
                 }

--- a/iXBRLViewerPlugin/viewer/src/js/summary.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/summary.test.js
@@ -7,7 +7,7 @@ function testConcept(typedDomainElement) {
     return {
         isTypedDimension: () => typedDomainElement !== undefined,
         typedDomainElement: () => typedDomainElement,
-        hasDefinition: () => true,
+        hasDefinition: true,
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/summary.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/summary.test.js
@@ -6,7 +6,8 @@ import { DocumentSummary } from "./summary.js";
 function testConcept(typedDomainElement) {
     return {
         isTypedDimension: () => typedDomainElement !== undefined,
-        typedDomainElement: () => typedDomainElement
+        typedDomainElement: () => typedDomainElement,
+        hasDefinition: () => true,
     }
 }
 


### PR DESCRIPTION
#### Reason for change

See #758 - this was error was caused by generating a viewer without the relevant taxonomy being available, meaning that  definitions for dimensions were not available, resulting in a typed dimension being treated as an explicit dimension, and hitting the exception [here](https://github.com/Arelle/ixbrl-viewer/blob/master/iXBRLViewerPlugin/viewer/src/js/summary.js#L78). 

#### Description of change

Add a property to `Concept` that allows us to check if the concept is backed by a taxonomy definition, and ignore dimensions missing definitions in the summary.

#### Steps to Test

Generate a viewer with typed dimensions and a non-existent taxonomy, or generate a viewer and manually delete concept definitions for typed dimensions from the JSON and confirm that the viewer loads correctly.

**review**:
@Arelle/arelle
@paulwarren-wk

Fixes #758 .