### PR TITLE
Dark Mode: Text Block Viewer - Black Text on Black Background

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/text-block-viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/text-block-viewer.less
@@ -16,6 +16,8 @@
     }
 
     iframe {
+      background-color:white;
+      color:black;
       margin: 1.4rem 0;
       border: solid 1px #ccc;
       flex-grow: 1;


### PR DESCRIPTION
#### Reason for change
The viewer pane and text block dialog iframes do not inherit CSS from the parent document, but they do have transparent backgrounds. [We hard code](https://github.com/Arelle/ixbrl-viewer/blob/bb2d91c07c675b17fd57754379dfab5b82613152/iXBRLViewerPlugin/viewer/src/less/inspector.less#L142-L143) the main viewer color and background-color values to black and white respectively, but did not for the text block viewer iframe. This caused the text block viewer pane to show black text on a black background when dark mode was enabled.

| Master | Master (with text selected) | PR |
| ------- | --------------------------- | --- |
| <img width="350" alt="Screenshot 2025-01-17 at 10 42 27 PM" src="https://github.com/user-attachments/assets/2dabaa18-3c6e-4440-9449-e4c9fe4f2337" /> | <img width="350" alt="Screenshot 2025-01-17 at 10 42 33 PM" src="https://github.com/user-attachments/assets/88b11a24-271c-4cc3-93c5-e1ee345ba0bf" /> | <img width="350" alt="Screenshot 2025-01-17 at 10 43 20 PM" src="https://github.com/user-attachments/assets/f368bf8a-ce9d-49bf-9575-46b6d4baee50" /> |


#### Description of change
This change uses the same hard coded color and background colors for the text block viewer dialog as we use for the document viewer.

#### Steps to Test
* Enable dark mode.
* Select a text block fact.
* Click the expand fact value button.

**review**:
@Arelle/arelle
@paulwarren-wk
