### PR TITLE
Various fixes for display of footnotes in inspector

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/html/footnote-details.html
+++ b/iXBRLViewerPlugin/viewer/src/html/footnote-details.html
@@ -3,7 +3,7 @@ See COPYRIGHT.md for copyright information
 -->
 
 <div>
-  <table class="fact-properties">
+  <table class="property-table fact-properties">
     <tr class="value">
       <th data-i18n="footnotes.footnote">Footnote</th>
       <td><span class="value"></span> <button class="show-all inline-button">[...]</button></td>

--- a/iXBRLViewerPlugin/viewer/src/js/footnote.js
+++ b/iXBRLViewerPlugin/viewer/src/js/footnote.js
@@ -21,6 +21,12 @@ export class Footnote {
         return this.textContent();
     }
 
+    readableValueHTML() {
+        const span = document.createElement("span");
+        span.append(document.createTextNode(this.textContent()));
+        return span;
+    }
+
     isTextBlock() {
         return false;
     }

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -1208,7 +1208,7 @@ export class Inspector {
         const valueHTML = item.readableValueHTML();
         const tr = $('tr.value', context);
         const valueSpan = tr.find('td .value').empty();
-        if (!item.isNumeric() && !showAll) {
+        if (!(item instanceof Fact && item.isNumeric()) && !showAll) {
             const vv = wrapLabel(valueHTML.textContent, 120);
             if (vv.length > 1) {
                 tr.addClass("truncated");
@@ -1463,6 +1463,7 @@ export class Inspector {
         } 
         else { 
             $('#inspector').removeClass('no-fact-selected').removeClass("hidden-fact").removeClass("html-hidden-fact");
+            $('#inspector .tags').show();
 
             $('#inspector .fact-inspector')
                 .empty()
@@ -1512,6 +1513,7 @@ export class Inspector {
             else if (cf instanceof Footnote) {
                 $('#inspector').addClass('footnote-mode');
                 $('#inspector .footnote-details .footnote-facts').empty().append(this._footnoteFactsHTML(cf));
+                $('#inspector .tags').hide();
             }
             $('.fact-details').localize();
         }

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -689,19 +689,6 @@
             }
           }
 
-          .select-icon {
-            float: right;
-            .square-button();
-            .clickable();
-
-            &:first-of-type {
-              margin-left: 0.5rem;
-            }
-
-            &::before {
-              .icon-select();
-            }
-          }
 
           .more-results {
             .clickable();
@@ -1296,6 +1283,20 @@
   .fact-list {
     .fact-list-item {
       .block-list-item();
+
+      .select-icon {
+        float: right;
+        .square-button();
+        .clickable();
+
+        &:first-of-type {
+          margin-left: 0.5rem;
+        }
+
+        &::before {
+          .icon-select();
+        }
+      }
 
       .title {
         color: var(--colour-text-title);


### PR DESCRIPTION
#### Reason for change

A number of regressions in the behaviour when footnotes are focused in the inspector:

* Exception when fact is selected due to missing `readableValueHTML` method.
* Small glitch in top right of footnote display due to empty target document tag being shown.
* "show-all" ellipsis not disappearing after it is clicked.
* Missing icons in list of linked concepts.

#### Description of change

* Implemented `readableValueHTML` for footnotes.
* Avoid calling `isNumeric` on footnotes.
* Added `property-table` class to footnote details table.
* Moved definition of `.select-icon` class so that apples to all fact lists.

#### Steps to Test

Open a document with footnotes. Click on any footnote, and confirm that footnote is displayed correctly in fact inspector.

**review**:
@Arelle/arelle
@paulwarren-wk
