### PR TITLE
Switch to using CSS inheritance for highlighting sub-elements

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -765,10 +765,9 @@ export class Viewer {
                         }
                     }
             });
-            $(".ixbrl-sub-element", this._contents).addClass("ixbrl-highlight");
         }
         else {
-            $(".ixbrl-element, .ixbrl-sub-element", this._contents).removeClass(
+            $(".ixbrl-element", this._contents).removeClass(
                 (i, className) => (className.match (/(^|\s)ixbrl-highlight\S*/g) || []).join(' ')
             );
         }

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -16,16 +16,22 @@
   --colour-related-fact: @colour-related-fact;
 }
 
-.ixbrl-highlight:not(.ixbrl-no-highlight) {
-  // To ensure highlighting takes place, !important is used to override inline styles.
-  // For example: overrides highlighting applied inline to alternate table rows.
-  background-color: var(--colour-highlight-default) !important; // Override inline styles
+// To ensure highlighting takes place, !important is used to override inline styles.
+// For example: overrides highlighting applied inline to alternate table rows.
 
-  &.ixbrl-highlight-1 {
+.ixbrl-highlight {
+  &:not(.ixbrl-no-highlight),
+  & .ixbrl-sub-element {
+      background-color: var(--colour-highlight-default) !important; // Override inline styles
+  }
+
+  &:not(.ixbrl-no-highlight).ixbrl-highlight-1, 
+  &.ixbrl-highlight-1 .ixbrl-sub-element {
     background-color: var(--colour-highlight-1) !important; // Override inline styles
   }
 
-  &.ixbrl-highlight-2 {
+  &:not(.ixbrl-no-highlight) .ixbrl-highlight-2,
+  &.ixbrl-highlight-2 .ixbrl-sub-element {
     background-color: var(--colour-highlight-2) !important; // Override inline styles
   }
 }
@@ -42,13 +48,18 @@
   // Review mode disables namespace-specific highlighting in favor of all tagged
   // elements sharing the same default highlight color, other colors are used for
   // untagged highlighting defined above.
-  background-color: var(--colour-highlight-default) !important; // Override inline styles
+  &, 
+  & .ixbrl-sub-element {
+      background-color: var(--colour-highlight-default) !important; // Override inline styles
+  }
 
-  &.ixbrl-highlight-1 {
+  &.ixbrl-highlight-1,
+  &.ixbrl-highlight-1 .ixbrl-sub-element {
     background-color: var(--colour-highlight-default) !important; // Override inline styles
   }
 
-  &.ixbrl-highlight-2 {
+  &.ixbrl-highlight-2,
+  &.ixbrl-highlight-2 .ixbrl-sub-element {
     background-color: var(--colour-highlight-default) !important; // Override inline styles
   }
 }


### PR DESCRIPTION
#### Reason for change

Performance issues when loading documents with very large numbers of sub-elements, causing the following exception when loading:

```
ixbrlviewer.js:2 Uncaught RangeError: Maximum call stack size exceeded
```

#### Description of change

Rather than adding `ixbrl-highlight` individually to every sub-element, only add it to the enclosing `.ixbrl-element` node, and use CSS rules to add it to the sub elements.

This PR does not improve performance with element selection (the outline applied when an element is selected). I intend to tackle this as a separate PR as it's a bit more involved.

#### Steps to Test

Confirm that problematic documents (e.g. [this one](https://filings.xbrl.org/5493006QMFDDMYWIAM13/2023-12-31/ESEF/ES/0/) ) now load correctly.

**review**:
@Arelle/arelle
@paulwarren-wk
