### PR TITLE
Use CSS rules for element selection

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -605,7 +605,7 @@ export class Viewer {
     }
 
     clearHighlighting() {
-        $("body", this._iframes.contents()).find(".ixbrl-element, .ixbrl-sub-element").removeClass("ixbrl-selected").removeClass("ixbrl-related").removeClass("ixbrl-linked-highlight");
+        $("body", this._iframes.contents()).find(".ixbrl-element").removeClass("ixbrl-selected").removeClass("ixbrl-related").removeClass("ixbrl-linked-highlight");
     }
 
     _ixIdsForElement(e) {
@@ -702,15 +702,17 @@ export class Viewer {
         return this._ixNodeMap[vuid].wrapperNodes;
     }
 
-    elementsForItemIds(vuids) {
-        return $(vuids.map(vuid => this.elementsForItemId(vuid).get()).flat());
+    // Returns a jQuery node list containing the primary wrapper node for each
+    // vuid provided
+    primaryElementsForItemIds(vuids) {
+        return $(vuids.map(vuid => this.elementsForItemId(vuid).first().get(0)));
     }
 
     /*
      * Add or remove a class to an item (fact or footnote) and any continuation elements
      */
     changeItemClass(vuid, highlightClass, removeClass) {
-        const elements = this.elementsForItemIds([vuid].concat(this.itemContinuationMap[vuid]))
+        const elements = this.primaryElementsForItemIds([vuid].concat(this.itemContinuationMap[vuid]))
         if (removeClass) {
             elements.removeClass(highlightClass);
         }
@@ -757,7 +759,7 @@ export class Viewer {
                     if (ixn !== undefined ) {
                         const item = reportSet.getItemById(ixn.id);
                         if (item !== undefined) {
-                            const elements = viewer.elementsForItemIds(ixn.chainIXIds());
+                            const elements = viewer.primaryElementsForItemIds(ixn.chainIXIds());
                             const i = groups[item.conceptQName().prefix];
                             if (i !== undefined) {
                                 elements.addClass("ixbrl-highlight-" + i);

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -21,17 +21,17 @@
 
 .ixbrl-highlight {
   &:not(.ixbrl-no-highlight),
-  & .ixbrl-sub-element {
+  & .ixbrl-sub-element:not(.ixbrl-no-highlight) {
       background-color: var(--colour-highlight-default) !important; // Override inline styles
   }
 
   &:not(.ixbrl-no-highlight).ixbrl-highlight-1, 
-  &.ixbrl-highlight-1 .ixbrl-sub-element {
+  &.ixbrl-highlight-1 .ixbrl-sub-element:not(.ixbrl-no-highlight) {
     background-color: var(--colour-highlight-1) !important; // Override inline styles
   }
 
   &:not(.ixbrl-no-highlight) .ixbrl-highlight-2,
-  &.ixbrl-highlight-2 .ixbrl-sub-element {
+  &.ixbrl-highlight-2 .ixbrl-sub-element:not(.ixbrl-no-highlight) {
     background-color: var(--colour-highlight-2) !important; // Override inline styles
   }
 }
@@ -46,79 +46,73 @@
 
 .review .ixbrl-highlight {
   &:not(.ixbrl-no-highlight).ixbrl-highlight-1, 
-  &.ixbrl-highlight-1 .ixbrl-sub-element {
+  &.ixbrl-highlight-1 .ixbrl-sub-element:not(.ixbrl-no-highlight) {
     background-color: var(--colour-highlight-default) !important; // Override inline styles
   }
 
   &:not(.ixbrl-no-highlight) .ixbrl-highlight-2,
-  &.ixbrl-highlight-2 .ixbrl-sub-element {
+  &.ixbrl-highlight-2 .ixbrl-sub-element:not(.ixbrl-no-highlight) {
     background-color: var(--colour-highlight-default) !important; // Override inline styles
   }
 }
 
-div,
-span {
-  &:not(.ixbrl-no-highlight) {
-    &.ixbrl-selected {
-      outline: solid 0.125em var(--colour-primary-focus);
-      outline-offset: 0.0625em;
-    }
+// Apply related fact highlighting (used for calc contributors)
+&.ixbrl-related {
+  &:not(.ixbrl-no-highlight),
+  .ixbrl-sub-element:not(.ixbrl-no-highlight) {
+    outline: solid 0.125em var(--colour-related-fact);
+    outline-offset: 0.0625em;
 
-    &.ixbrl-element,
-    &.ixbrl-sub-element {
-      &:hover:not(.ixbrl-selected) {
-        outline: dashed 0.125em var(--colour-primary-focus);
-        outline-offset: 0.0625em;
-      }
+    td&, th& {
+      outline-offset: -0.0625em;
     }
   }
 }
 
-:not(.ixbrl-no-highlight) {
-  &.ixbrl-element,
-  &.ixbrl-sub-element {
+// Apply linked fact highlighting (used when hovering on facts in inspector)
+&.ixbrl-linked-highlight {
+  &:not(.ixbrl-no-highlight),
+  .ixbrl-sub-element:not(.ixbrl-no-highlight) {
+    outline: dashed 0.125em var(--colour-linked-fact);
+    outline-offset: 0.0625em;
+
+    td&, th& {
+      outline-offset: -0.0625em;
+    }
+  }
+}
+
+// Apply dashed outline to iXBRL elements on hover
+// Should override previous rule
+.ixbrl-element:not(.ixbrl-no-highlight),
+.ixbrl-sub-element:not(.ixbrl-no-highlight) {
+  &:hover {
+    outline: dashed 0.125em var(--colour-primary-focus);
+    outline-offset: 0.0625em;
     cursor: pointer;
 
-    &.ixbrl-related {
-      outline: dashed 0.125em var(--colour-related-fact);
+    td&, th& {
+      outline-offset: -0.0625em;
+    }
+  }
+}
 
-      &:not(td, th) {
-        outline-offset: 0.0625em;
+// Apply solid outline to selected elements
+&.ixbrl-selected {
+  &:not(.ixbrl-no-highlight),
+  .ixbrl-sub-element:not(.ixbrl-no-highlight) {
+    // This rule needs to override the previous one so that already selected
+    // elements don't get a dashed line on hover
+    &,
+    &:hover {
+      outline: solid 0.125em var(--colour-primary-focus);
+      outline-offset: 0.0625em;
+
+      td&, th& {
+        outline-offset: -0.0625em;
       }
     }
   }
-}
-
-td,
-th {
-  &:not(.ixbrl-no-highlight) {
-    &.ixbrl-selected {
-      outline: solid 0.125em var(--colour-primary-focus) !important;
-      outline-offset: -0.0625em !important;
-    }
-
-    &.ixbrl-element:hover:not(.ixbrl-selected),
-    &.ixbrl-sub-element:hover:not(.ixbrl-selected) {
-      outline: dashed 0.125em var(--colour-primary-focus) !important;
-      outline-offset: -0.0625em !important;
-    }
-  }
-
-  &.ixbrl-related {
-    outline-offset: -0.0625em !important;
-  }
-}
-
-.ixbrl-related.ixbrl-linked-highlight:not(.ixbrl-no-highlight),
-.ixbrl-linked-highlight:not(.ixbrl-no-highlight) {
-  .linked-highlight-text();
-}
-
-td.ixbrl-related.ixbrl-linked-highlight:not(.ixbrl-no-highlight),
-td.ixbrl-linked-highlight:not(.ixbrl-no-highlight) {
-  .linked-highlight-cell();
-
-  outline-offset: -0.0625em;
 }
 
 div.ixbrl-table-handle {


### PR DESCRIPTION
#### Reason for change

Slow performance on documents with large numbers of sub-elements (absolutely position elements within `ix` elements)

#### Description of change

This is follow-on to #806, and extends the approach of using CSS rules for highlighting sub elements within selected elements.

This gives significantly better performance when switching facts on documents with elements with large numbers of absolutely positioned sub elements.

#### Steps to Test

Confirm that borders applied to elements on hover and selection are as before, but faster.

[This document](https://filings.xbrl.org/5493006QMFDDMYWIAM13/2023-12-31/ESEF/ES/0/) shows the performance issue - open the document and press the previous fact button to select one of the problematic facts at the end of the document.

**review**:
@Arelle/arelle
@paulwarren-wk
