### PR TITLE
Fix highlighting of continuations.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -68,6 +68,8 @@ export class Viewer {
                         viewer._preProcessiXBRL($(this).contents().find("body").get(0), reportIndex, docIndex, false);
                     });
 
+                    viewer._setContinuationMaps();
+
                     /* Call plugin promise for each document in turn */
                     (async function () {
                         for (const [docIndex, iframe] of viewer._iframes.toArray().entries()) {
@@ -343,6 +345,12 @@ export class Viewer {
             }
         }
         this.itemContinuationMap = itemContinuationMap;
+    }
+
+    _setContinuationMaps() {
+        for (const [itemId, itemContinuations] of Object.entries(this.itemContinuationMap)) {
+            this._ixNodeMap[itemId].continuations = itemContinuations.map(id => this._ixNodeMap[id]);
+        }
     }
 
     _getOrCreateIXNode(vuid, nodes, docIndex, isHidden) {


### PR DESCRIPTION
#### Reason for change

Bug: when "highlight all tags" is selected, continuation elements are always shown in the default highlight color, regardless of namespace.

#### Description of change

This was a regression introduced in e3b91fefab26d5b9eff1250a73e13dce29fcae1f : the continuation code was refactored, but in doing so, we were no longer setting `.continuations` on `IXNode`.

This introduces a new step in the document preparation process to set the `.continuations` property on all `IXNode`s.

#### Steps to Test

Confirm that in a document with multiple namespaces, any facts with continuation content are highlighted in the right color.

**review**:
@Arelle/arelle
@paulwarren-wk
