### PR TITLE
Fall back to RTD user guide for Help > User Guide link

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -421,6 +421,17 @@ export class Inspector {
         }
     }
 
+    buildUserGuideLink() {
+        $('.top-bar-controls #user-guide-link').remove();
+        const userGuideUrl = this._iv.getGuideLinkUrl();
+        const userGuideLink = $('<a></a>')
+                .attr('href', userGuideUrl)
+                .attr('id', 'user-guide-link')
+                .attr('target', '_blank')
+                .text(i18next.t("menu.userGuide"));
+        userGuideLink.insertBefore('#toggle-dark-mode');
+    }
+
     changeApplicationLanguage(lang) {
         localStorage.setItem(STORAGE_APP_LANGUAGE, lang);
         i18next.changeLanguage(lang);
@@ -434,6 +445,7 @@ export class Inspector {
         this.buildHomeLink()
         this.buildToolbarHighlightMenu();
         this.buildHighlightKey();
+        this.buildUserGuideLink();
         this.update();
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -7,7 +7,7 @@ import { Viewer, DocumentTooLargeError } from "./viewer.js";
 import { Inspector } from "./inspector.js";
 import { initializeTheme } from './theme.js';
 import { TaxonomyNamer } from './taxonomynamer.js';
-import { FEATURE_GUIDE_LINK, FEATURE_REVIEW, FEATURE_SUPPORT_LINK, FEATURE_SURVEY_LINK, moveNonAppAttributes } from "./util";
+import { FEATURE_GUIDE_LINK, FEATURE_REVIEW, FEATURE_SUPPORT_LINK, FEATURE_SURVEY_LINK, USER_GUIDE_URL, moveNonAppAttributes } from "./util";
 
 const featureFalsyValues = new Set([undefined, null, '', 'false', false]);
 
@@ -127,7 +127,7 @@ export class iXBRLViewer {
 
     getGuideLinkUrl() {
         if (!this.isStaticFeatureEnabled(FEATURE_GUIDE_LINK)) {
-            return null;
+            return USER_GUIDE_URL;
         }
         return this.resolveRelativeUrl(this.getStaticFeatureValue(FEATURE_GUIDE_LINK));
     }

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
@@ -5,7 +5,8 @@ import {
     FEATURE_GUIDE_LINK,
     FEATURE_REVIEW,
     FEATURE_SUPPORT_LINK,
-    FEATURE_SURVEY_LINK
+    FEATURE_SURVEY_LINK,
+    USER_GUIDE_URL,
 } from "./util";
 describe("Feature enablement", () => {
     var viewer = null;
@@ -183,7 +184,7 @@ describe("Guide link enablement", () => {
 
     test("Guide link enabled by query", () => {
         viewer.setFeatures({}, FEATURE_GUIDE_LINK + '=/guide')
-        expect(viewer.getGuideLinkUrl()).toEqual(null);
+        expect(viewer.getGuideLinkUrl()).toEqual(USER_GUIDE_URL);
     });
 
     test("Guide link disabled by query", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -32,6 +32,7 @@ export const STORAGE_APP_LANGUAGE = "ixbrl-viewer-app-language";
 export const STORAGE_THEME = "ixbrl-viewer-theme";
 export const STORAGE_HIGHLIGHT_FACTS = "ixbrl-viewer-highlight-all-facts";
 export const STORAGE_HOME_LINK_QUERY = "ixbrl-viewer-home-link-query";
+export const USER_GUIDE_URL = "https://arelle-ixbrl-viewer.readthedocs.io/";
 
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date


### PR DESCRIPTION
#### Description of change
When the user guide feature is not enabled, fall back to the URL for the lastest ixbrl-viewer RTD documentation.

Add User Guide link to the header as well.

Note: I considered linking to the documentation version that matched the version of the viewer being used, but felt that wouldn't be best due to the user guide being in an early state right now.

#### Steps to Test
CI

![image](https://github.com/user-attachments/assets/859a5503-8b89-46b1-bacd-6e3b1a30a0c2)


**review**:
@Arelle/arelle
@paulwarren-wk
