### PR TITLE
Apply default font to button elements.

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -95,1357 +95,1354 @@
   }
 }
 
-#ixv {
-  /* Specify these here, not on body in case the iXBRL document has its own
-   * style attribute */
-  &,
-  table,
-  dialog {
-    .default-font();
-    .text-md();
+body,
+table,
+dialog,
+button {
+  .default-font();
+  .text-md();
+}
+
+a {
+  text-decoration: none;
+  color: var(--colour-primary);
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+#ixv-progress {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  width: 500px;
+  height: 200px;
+  background-color: var(--colour-bg);
+  border: solid #000 1px;
+  text-align: center;
+}
+
+#viewer-pane {
+  width: 75%;
+  box-sizing: border-box;
+  position: fixed;
+  left: 0;
+  top: var(--top-bar-height);
+  bottom: 0;
+  z-index: 1;
+  display: flex;
+  flex-flow: column;
+
+  .ixds-tabs {
+    display: none;
+    flex: 0 1 auto;
   }
 
-  a {
-    text-decoration: none;
-    color: var(--colour-primary);
+  #iframe-container {
+    background-color:white;
+    color:black;
+    position: relative;
+    flex: 1 1 auto;
 
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-
-  #ixv-progress {
-    position: fixed;
-    top: 20px;
-    left: 20px;
-    width: 500px;
-    height: 200px;
-    background-color: var(--colour-bg);
-    border: solid #000 1px;
-    text-align: center;
-  }
-
-  #viewer-pane {
-    width: 75%;
-    box-sizing: border-box;
-    position: fixed;
-    left: 0;
-    top: var(--top-bar-height);
-    bottom: 0;
-    z-index: 1;
-    display: flex;
-    flex-flow: column;
-
-    .ixds-tabs {
-      display: none;
-      flex: 0 1 auto;
-    }
-
-    #iframe-container {
-      background-color:white;
-      color:black;
-      position: relative;
-      flex: 1 1 auto;
-
-      & > iframe {
-        width: 100%;
-        height: 100%;
-        box-sizing: border-box;
-        border: none;
-      }
-
-      .zoom-in,
-      .zoom-out,
-      .print {
-        position: absolute;
-        right: 30px;
-        width: 20px;
-        height: 20px;
-        border: solid 1px #bbb;
-        background-color: rgb(225 225 225 / 70%);
-        justify-content: center;
-        display: flex;
-        align-items: center;
-        color: #777;
-        cursor: pointer;
-        user-select: none;
-      }
-
-      .zoom-in {
-        top: 15px;
-      }
-
-      .zoom-out {
-        top: 40px;
-      }
-
-      .print {
-        top: 75px;
-
-        &::after {
-          .icon-print();
-
-          font-size: 20px;
-        }
-      }
-
-      .zoom-in:hover,
-      .zoom-out:hover,
-      .print:hover {
-        background-color: rgb(128 128 128 / 70%);
-      }
-    }
-
-    .resize {
-      position: absolute;
-      top: 0;
-      width: 5px;
-      right: -5px;
-      bottom: 0;
-      z-index: 20;
-    }
-
-    /* This spacer stops drag events getting lost to the iframe */
-    .resize-spacer {
-      position: absolute;
-      top: 0;
-      width: 3px;
-      right: 0;
-      bottom: 0;
-      z-index: 20;
-    }
-  }
-
-  #top-bar {
-    .default-font();
-    .text-md();
-
-    display: flex;
-    align-items: center;
-    color: var(--colour-text);
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: var(--top-bar-height);
-    border-bottom: solid 1px #ccc;
-    z-index: 5;
-
-    #home-link {
-      font-size: 2.2rem;
-      font-weight: bold;
-      margin-left: 1rem;
-      margin-right: 1rem;
-    }
-
-    .header {
-      height: 100%;
-    }
-
-    .document-title {
-      box-sizing: border-box;
-      padding-right: 1.6rem;
-      line-height: var(--top-bar-height);
-      border-right: solid 0.1rem #ccc;
-      height: var(--top-bar-height);
-      overflow: hidden;
-      font-size: inherit;
-      font-weight: inherit;
-      margin: 0;
-    }
-
-    .top-bar-controls {
-      position: absolute;
-      display: flex;
-      right: 0;
-      top: 0;
-      line-height: var(--top-bar-height);
-      height: var(--top-bar-height);
-      background: var(--colour-bg);
-      padding-left: 1.8rem;
-
-      & > * {
-        margin-right: 0.8rem;
-      }
-
-      .horizontal-menu {
-        * {
-          vertical-align: middle;
-        }
-
-        .content > * {
-          position: relative;
-          top: -0.1rem;
-          margin-right: 0.6rem;
-        }
-      }
-
-
-      .highlight-key {
-        margin-left: 0.6rem;
-        margin-right: 1.5rem;
-        position: relative;
-
-        &::before {
-          .icon-question();
-
-          font-size: 1.6rem;
-        }
-
-        .popup-content {
-          position: absolute;
-          top: 3.2rem;
-          left: -2rem;
-          background: white;
-          color: black;
-          border: solid 1px black;
-          border-radius: 0.3rem;
-          line-height: 1.6rem;
-
-          .arrow {
-            position: absolute;
-            top: 0;
-            left: 1.1rem;
-            width: 1.5rem;
-            height: 1.5rem;
-            border-top: solid 0.1rem black;
-            border-left: solid 0.1rem black;
-            transform: translate(50%, -50%) rotate(45deg);
-            background: white;
-          }
-
-          .item {
-            white-space: nowrap;
-            margin: 1rem;
-            position: relative;
-
-            .sample {
-              display: inline-block;
-              width: 3.2rem;
-              height: 1.6rem;
-              margin-right: 1rem;
-            }
-
-            .sample-0 {
-              background: var(--colour-highlight-default);
-            }
-
-            .sample-1 {
-              background: var(--colour-highlight-1);
-            }
-
-            .sample-2 {
-              background: var(--colour-highlight-2);
-            }
-
-            .sample-3 {
-              background: var(--colour-highlight-3);
-            }
-
-            .sample-4 {
-              background: var(--colour-highlight-4);
-            }
-
-            .sample-5 {
-              background: var(--colour-highlight-5);
-            }
-          }
-        }
-      }
-
-      .validation-warning {
-        margin-left: 0.5rem;
-        font-size: 1.6rem;
-        display: none;
-        cursor: pointer;
-
-        &::before {
-          .icon-warning();
-        }
-      }
-
-      #toggle-dark-mode {
-        border: none;
-
-        &::before {
-          .icon-dark-mode();
-
-          cursor: pointer;
-        }
-      }
-
-      .menu .menu-title::before {
-        .icon-cog();
-
-        font-size: 2rem;
-      }
-    }
-  }
-
-  #inspector {
-    display: flex;
-    flex-direction: column;
-
-    h1,
-    h2,
-    h3 {
-      font-weight: normal;
+    & > iframe {
       width: 100%;
+      height: 100%;
       box-sizing: border-box;
-      color: var(--colour-text-title);
+      border: none;
     }
 
-    h2 {
-      text-align: center;
-      font-size: 1.8rem;
-      line-height: 3.2rem;
-      margin: 0.8rem 0;
-    }
-
-    h3 {
-      .text-md();
-    }
-
-    h4 {
-      font-weight: bold;
-      color: var(--colour-text-title);
-      margin-bottom: 1.4em;
-    }
-
-    #inspector-head {
-      padding: 0;
-      position: relative;
-      border-bottom: solid 1px var(--colour-border-grey);
-
-      .controls {
-        position: relative;
-        height: 3.2rem;
-        padding: 0.8rem 0.9rem;
-        display: flex;
-
-        & > * {
-          margin: 0.8rem 0.9rem;
-        }
-
-        .search-button {
-          .square-button();
-
-          &::before {
-            .icon-search();
-
-            position: relative;
-          }
-        }
-
-        .outline-button {
-          .square-button();
-
-          &::before {
-            .icon-outline();
-
-            position: relative;
-          }
-        }
-
-        .summary-button {
-          .square-button();
-
-          &::before {
-            .icon-summary();
-
-            position: relative;
-          }
-        }
-
-        .ixbrl-prev-tag {
-          .square-button();
-
-          margin-left: auto;
-
-          &::before {
-            .icon-chevron-left();
-          }
-        }
-
-        .ixbrl-next-tag {
-          .square-button();
-
-          &::before {
-            .icon-chevron-right();
-          }
-        }
-      }
-    }
-
-    .inspector-container {
-      flex-grow: 1;
-      overflow: hidden;
+    .zoom-in,
+    .zoom-out,
+    .print {
+      position: absolute;
+      right: 30px;
+      width: 20px;
+      height: 20px;
+      border: solid 1px #bbb;
+      background-color: rgb(225 225 225 / 70%);
+      justify-content: center;
       display: flex;
-      flex-direction: column;
+      align-items: center;
+      color: #777;
+      cursor: pointer;
+      user-select: none;
+    }
 
-      .inspector-title {
-        text-align: center;
-        position: relative;
-        margin: 0.8rem 0;
+    .zoom-in {
+      top: 15px;
+    }
 
-        h2 {
-          margin: 0;
-          padding: 0;
-        }
+    .zoom-out {
+      top: 40px;
+    }
 
-        .back {
-          .square-button-bare();
+    .print {
+      top: 75px;
 
-          top: 0;
-          left: 0.9rem;
-          position: absolute;
+      &::after {
+        .icon-print();
 
-          &::before {
-            .icon-chevron-left();
-          }
-        }
+        font-size: 20px;
+      }
+    }
+
+    .zoom-in:hover,
+    .zoom-out:hover,
+    .print:hover {
+      background-color: rgb(128 128 128 / 70%);
+    }
+  }
+
+  .resize {
+    position: absolute;
+    top: 0;
+    width: 5px;
+    right: -5px;
+    bottom: 0;
+    z-index: 20;
+  }
+
+  /* This spacer stops drag events getting lost to the iframe */
+  .resize-spacer {
+    position: absolute;
+    top: 0;
+    width: 3px;
+    right: 0;
+    bottom: 0;
+    z-index: 20;
+  }
+}
+
+#top-bar {
+  .default-font();
+  .text-md();
+
+  display: flex;
+  align-items: center;
+  color: var(--colour-text);
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--top-bar-height);
+  border-bottom: solid 1px #ccc;
+  z-index: 5;
+
+  #home-link {
+    font-size: 2.2rem;
+    font-weight: bold;
+    margin-left: 1rem;
+    margin-right: 1rem;
+  }
+
+  .header {
+    height: 100%;
+  }
+
+  .document-title {
+    box-sizing: border-box;
+    padding-right: 1.6rem;
+    line-height: var(--top-bar-height);
+    border-right: solid 0.1rem #ccc;
+    height: var(--top-bar-height);
+    overflow: hidden;
+    font-size: inherit;
+    font-weight: inherit;
+    margin: 0;
+  }
+
+  .top-bar-controls {
+    position: absolute;
+    display: flex;
+    right: 0;
+    top: 0;
+    line-height: var(--top-bar-height);
+    height: var(--top-bar-height);
+    background: var(--colour-bg);
+    padding-left: 1.8rem;
+
+    & > * {
+      margin-right: 0.8rem;
+    }
+
+    .horizontal-menu {
+      * {
+        vertical-align: middle;
       }
 
-      .search-controls {
-        margin: 0 0 0.8rem;
+      .content > * {
+        position: relative;
+        top: -0.1rem;
+        margin-right: 0.6rem;
+      }
+    }
 
-        .search-input {
-          display: flex;
-          padding: 0 0.9rem;
 
-          input#ixbrl-search {
-            flex-grow: 1;
+    .highlight-key {
+      margin-left: 0.6rem;
+      margin-right: 1.5rem;
+      position: relative;
+
+      &::before {
+        .icon-question();
+
+        font-size: 1.6rem;
+      }
+
+      .popup-content {
+        position: absolute;
+        top: 3.2rem;
+        left: -2rem;
+        background: white;
+        color: black;
+        border: solid 1px black;
+        border-radius: 0.3rem;
+        line-height: 1.6rem;
+
+        .arrow {
+          position: absolute;
+          top: 0;
+          left: 1.1rem;
+          width: 1.5rem;
+          height: 1.5rem;
+          border-top: solid 0.1rem black;
+          border-left: solid 0.1rem black;
+          transform: translate(50%, -50%) rotate(45deg);
+          background: white;
+        }
+
+        .item {
+          white-space: nowrap;
+          margin: 1rem;
+          position: relative;
+
+          .sample {
+            display: inline-block;
+            width: 3.2rem;
+            height: 1.6rem;
             margin-right: 1rem;
           }
 
-          .filter-toggle {
-            .square-button();
+          .sample-0 {
+            background: var(--colour-highlight-default);
+          }
 
-            &::before {
-              .icon-filter();
-            }
+          .sample-1 {
+            background: var(--colour-highlight-1);
+          }
+
+          .sample-2 {
+            background: var(--colour-highlight-2);
+          }
+
+          .sample-3 {
+            background: var(--colour-highlight-3);
+          }
+
+          .sample-4 {
+            background: var(--colour-highlight-4);
+          }
+
+          .sample-5 {
+            background: var(--colour-highlight-5);
           }
         }
+      }
+    }
 
-        .filter-info {
-          text-align: center;
-          font-style: italic;
-          margin-top: 0.8rem;
+    .validation-warning {
+      margin-left: 0.5rem;
+      font-size: 1.6rem;
+      display: none;
+      cursor: pointer;
+
+      &::before {
+        .icon-warning();
+      }
+    }
+
+    #toggle-dark-mode {
+      border: none;
+
+      &::before {
+        .icon-dark-mode();
+
+        cursor: pointer;
+      }
+    }
+
+    .menu .menu-title::before {
+      .icon-cog();
+
+      font-size: 2rem;
+    }
+  }
+}
+
+#inspector {
+  display: flex;
+  flex-direction: column;
+
+  h1,
+  h2,
+  h3 {
+    font-weight: normal;
+    width: 100%;
+    box-sizing: border-box;
+    color: var(--colour-text-title);
+  }
+
+  h2 {
+    text-align: center;
+    font-size: 1.8rem;
+    line-height: 3.2rem;
+    margin: 0.8rem 0;
+  }
+
+  h3 {
+    .text-md();
+  }
+
+  h4 {
+    font-weight: bold;
+    color: var(--colour-text-title);
+    margin-bottom: 1.4em;
+  }
+
+  #inspector-head {
+    padding: 0;
+    position: relative;
+    border-bottom: solid 1px var(--colour-border-grey);
+
+    .controls {
+      position: relative;
+      height: 3.2rem;
+      padding: 0.8rem 0.9rem;
+      display: flex;
+
+      & > * {
+        margin: 0.8rem 0.9rem;
+      }
+
+      .search-button {
+        .square-button();
+
+        &::before {
+          .icon-search();
+
           position: relative;
-
-          .reset {
-            .bare-button();
-            .text-md();
-
-            position: absolute;
-            right: 0.8rem;
-            top: -0.3rem;
-          }
         }
+      }
 
-        &:not(.show-filters) .search-filters {
-          display: none;
-        }
+      .outline-button {
+        .square-button();
 
-        &.active-filters .filter-toggle {
-          color: var(--colour-primary);
-        }
+        &::before {
+          .icon-outline();
 
-        &:not(.active-filters) .reset {
-          display: none;
-        }
-
-        .search-filters {
           position: relative;
-          // Ensure the filter pane never grows too large to hide the results pane
-          max-height: 60vh;
-          overflow-y: auto;
-          padding: 0 0.9rem;
+        }
+      }
 
+      .summary-button {
+        .square-button();
 
-          h3 {
-            border: none;
-            font-weight: bold;
-            padding-bottom: 0;
+        &::before {
+          .icon-summary();
 
-            button {
-              font-weight: inherit;
-            }
+          position: relative;
+        }
+      }
+
+      .ixbrl-prev-tag {
+        .square-button();
+
+        margin-left: auto;
+
+        &::before {
+          .icon-chevron-left();
+        }
+      }
+
+      .ixbrl-next-tag {
+        .square-button();
+
+        &::before {
+          .icon-chevron-right();
+        }
+      }
+    }
+  }
+
+  .inspector-container {
+    flex-grow: 1;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+
+    .inspector-title {
+      text-align: center;
+      position: relative;
+      margin: 0.8rem 0;
+
+      h2 {
+        margin: 0;
+        padding: 0;
+      }
+
+      .back {
+        .square-button-bare();
+
+        top: 0;
+        left: 0.9rem;
+        position: absolute;
+
+        &::before {
+          .icon-chevron-left();
+        }
+      }
+    }
+
+    .search-controls {
+      margin: 0 0 0.8rem;
+
+      .search-input {
+        display: flex;
+        padding: 0 0.9rem;
+
+        input#ixbrl-search {
+          flex-grow: 1;
+          margin-right: 1rem;
+        }
+
+        .filter-toggle {
+          .square-button();
+
+          &::before {
+            .icon-filter();
           }
+        }
+      }
 
-          .filter-group {
-            display: flex;
-            flex-wrap: wrap;
-            justify-content: space-between;
-            margin-bottom: 0.4em;
+      .filter-info {
+        text-align: center;
+        font-style: italic;
+        margin-top: 0.8rem;
+        position: relative;
 
-            .control-label {
-              white-space: nowrap;
-              margin-right: 2em;
-              width: 6em;
-            }
+        .reset {
+          .bare-button();
+          .text-md();
 
-            input,
-            select,
-            textarea {
-              flex-basis: 12em;
-              flex-grow: 2;
-            }
+          position: absolute;
+          right: 0.8rem;
+          top: -0.3rem;
+        }
+      }
+
+      &:not(.show-filters) .search-filters {
+        display: none;
+      }
+
+      &.active-filters .filter-toggle {
+        color: var(--colour-primary);
+      }
+
+      &:not(.active-filters) .reset {
+        display: none;
+      }
+
+      .search-filters {
+        position: relative;
+        // Ensure the filter pane never grows too large to hide the results pane
+        max-height: 60vh;
+        overflow-y: auto;
+        padding: 0 0.9rem;
+
+
+        h3 {
+          border: none;
+          font-weight: bold;
+          padding-bottom: 0;
+
+          button {
+            font-weight: inherit;
           }
+        }
+
+        .filter-group {
+          display: flex;
+          flex-wrap: wrap;
+          justify-content: space-between;
+          margin-bottom: 0.4em;
 
           .control-label {
-            font-weight: bold;
-            margin-bottom: 0.6em;
-            margin-top: 0.8em;
+            white-space: nowrap;
+            margin-right: 2em;
+            width: 6em;
           }
 
-          select {
-            width: 100%;
+          input,
+          select,
+          textarea {
+            flex-basis: 12em;
+            flex-grow: 2;
           }
+        }
 
-          .checkboxes {
-            display: flex;
-            flex-wrap: wrap;
+        .control-label {
+          font-weight: bold;
+          margin-bottom: 0.6em;
+          margin-top: 0.8em;
+        }
 
-            & > div {
-              margin: 1.2rem 0;
-              flex-grow: 1;
+        select {
+          width: 100%;
+        }
 
-              input {
-                vertical-align: middle;
-              }
+        .checkboxes {
+          display: flex;
+          flex-wrap: wrap;
+
+          & > div {
+            margin: 1.2rem 0;
+            flex-grow: 1;
+
+            input {
+              vertical-align: middle;
             }
           }
+        }
 
 
-          .datatype-conflict-warning {
-            margin: 1rem 0;
-            color: var(--colour-warning);
-            display: none;
-          }
+        .datatype-conflict-warning {
+          margin: 1rem 0;
+          color: var(--colour-warning);
+          display: none;
+        }
+      }
+    }
+
+    .inspector-body {
+      border-top: solid 1px var(--colour-border-grey);
+      width: 100%;
+      position: relative;
+      overflow-y: auto;
+      flex-grow: 1;
+
+      .no-fact-overlay,
+      .no-outline-overlay {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 80%;
+        text-align: center;
+        color: var(--colour-text-light);
+
+        .no-fact-overlay-icon::before {
+          .icon-tag();
+
+          font-size: 10rem;
+          line-height: normal;
+        }
+
+        .no-outline-overlay-icon::before {
+          .icon-outline();
+
+          font-size: 10rem;
+          line-height: normal;
+        }
+
+        .title {
+          font-size: x-large;
+          line-height: normal;
         }
       }
 
       .inspector-body {
-        border-top: solid 1px var(--colour-border-grey);
-        width: 100%;
-        position: relative;
         overflow-y: auto;
-        flex-grow: 1;
-
-        .no-fact-overlay,
-        .no-outline-overlay {
-          position: absolute;
-          left: 50%;
-          top: 50%;
-          transform: translate(-50%, -50%);
-          width: 80%;
-          text-align: center;
-          color: var(--colour-text-light);
-
-          .no-fact-overlay-icon::before {
-            .icon-tag();
-
-            font-size: 10rem;
-            line-height: normal;
-          }
-
-          .no-outline-overlay-icon::before {
-            .icon-outline();
-
-            font-size: 10rem;
-            line-height: normal;
-          }
-
-          .title {
-            font-size: x-large;
-            line-height: normal;
-          }
-        }
-
-        .inspector-body {
-          overflow-y: auto;
-          height: 100%;
-          position: relative;
-        }
-
-        .search-results {
-          overflow-y: auto;
-          height: 100%;
-          .panel-indent();
-
-          .search-overlay {
-            transform: translate(-50%, -50%);
-            position: absolute;
-            top: 50%;
-            left: 50%;
-            color: var(--colour-text-light);
-            width: 85%;
-
-            .search-overlay-icon {
-              text-align: center;
-              font-size: 10rem;
-              line-height: normal;
-
-              &::before {
-                .icon-search();
-              }
-            }
-
-            .search-overlay-text {
-              text-align: center;
-              font-size: medium;
-              line-height: normal;
-
-              .title {
-                font-size: x-large;
-                line-height: normal;
-              }
-            }
-          }
-
-
-          .more-results {
-            .clickable();
-
-            padding: 1rem;
-            text-align: center;
-          }
-        } /* search results */
-
-        .outline {
-          overflow-y: auto;
-          height: 100%;
-        }
-
-        .summary {
-          overflow-y: auto;
-          height: 100%;
-        }
-
-        .body {
-          .panel-indent();
-        }
-      } /* inspector body */
-    } /* inspector container */
-
-    .std-label {
-      margin-left: 30px;
-      min-height: 20px;
-      position: relative;
-
-      &::before {
-        color: var(--colour-primary);
-        content: "\2022";
-        position: absolute;
-        left: -20px;
-        font-size: x-large;
-      }
-    }
-
-    dt {
-      font-weight: bold;
-      color: var(--colour-text-title);
-      margin-bottom: 1.4rem;
-      margin-top: 1.4rem;
-    }
-
-    dd {
-      margin-inline-start: 2rem;
-    }
-
-    #concept {
-      margin-top: 20px;
-      font-size: small;
-      min-height: 25px;
-    }
-
-    #dimensions {
-      margin-left: 2rem;
-      margin-right: 2rem;
-      margin-bottom: 1rem;
-
-      .dimension {
+        height: 100%;
         position: relative;
-        margin: 1.5rem 0 1.5rem 1rem;
-
-        &::before {
-          .icon-dimension();
-
-          color: var(--colour-primary);
-          position: absolute;
-          top: 0;
-          left: -2.3rem;
-          font-size: 120%;
-        }
-      }
-
-      .dimension-value {
-        position: relative;
-        margin: 1.5rem 0 1.5rem 3.5rem;
-
-        &::before {
-          .icon-dimension-member();
-
-          position: absolute;
-          color: var(--colour-primary);
-          top: 0;
-          left: -2.3rem;
-          font-size: 120%;
-        }
-      }
-    }
-
-    .inline-button {
-      display: inline;
-      cursor: pointer;
-      color: var(--colour-primary);
-      padding: 0.3rem;
-      border: none;
-    }
-
-    .analyse {
-      margin-left: 0.4rem;
-    }
-
-    .analyse::before {
-      .icon-graph();
-
-      position: relative;
-      top: 1px;
-    }
-
-    .inspector-body .tags {
-      position: absolute;
-      top: 1.5rem;
-      right: 0.9rem;
-    }
-
-    .target-document-tag {
-      .tag();
-    }
-
-    .hidden-fact-tag,
-    .html-hidden-fact-tag {
-      .tag();
-
-      &.html-hidden-fact-tag {
-        background-color: #c63018;
-      }
-    }
-
-
-    .duplicates {
-      text-align: center;
-      width: 100%;
-      height: 3.2rem;
-      line-height: 3.2rem;
-
-      & > * {
-        vertical-align: middle;
-      }
-
-      .text {
-        margin: 0 5px;
-      }
-
-      .next,
-      .prev {
-        .square-button-bare();
-
-        position: relative;
-        display: inline-block;
-      }
-
-      .prev::before {
-        .icon-chevron-left();
-      }
-
-      .next::before {
-        .icon-chevron-right();
-      }
-    }
-
-    .concept td > div {
-      display: flex;
-
-      span.text {
-        white-space: nowrap;
-        position: relative;
-        flex-shrink: 1;
-        overflow: hidden;
-        text-overflow: ellipsis;
-      }
-
-      span.filler {
-        width: 0.7rem;
-        display: inline-block;
-        flex-shrink: 1000;
-      }
-
-      span.copy-icon {
-        flex-shrink: 0;
-      }
-    }
-
-    .documentation {
-      margin-top: 10px;
-      margin-left: 30px;
-      font-style: italic;
-      font-family: serif;
-    }
-
-    width: 25%;
-    position: absolute;
-    top: var(--top-bar-height);
-    right: 0;
-    bottom: 0;
-    box-sizing: border-box;
-    overflow: hidden;
-    border-left: solid 0.1rem var(--colour-border-grey);
-
-    .inspector-section {
-      padding-left: 0.9rem;
-      padding-right: 0.9rem;
-    }
-
-    .collapsible-section {
-      .collapsible-body {
-        .panel-indent();
-      }
-
-      .collapsible-header {
-        position: relative;
-        padding: 0 0 0.5rem 1.2rem;
-        cursor: pointer;
-        user-select: none;
-        white-space: nowrap;
-        border-bottom: solid 1px var(--colour-border-grey);
-
-        button:first-of-type {
-            .text-md();
-
-            border: none;
-            color: var(--colour-text-title);
-            text-align: left;
-            position: relative;
-            padding: 0.4rem 0.9rem 0.4rem 2.3rem;
-
-            &::before {
-              .icon-chevron-right();
-
-              font-size: 1.8rem;
-              position: absolute;
-              top: 0.4rem;
-              left: 0;
-              transform: rotate(90deg);
-              transition: all 0.25s ease;
-              display: inline-block;
-            }
-        }
-
-        .collapsible-subheader {
-          user-select: none;
-          font-weight: normal;
-          font-style: italic;
-          font-size: 1.3rem;
-          color: var(--colour-text-form-value);
-        }
-      }
-
-      &.collapsed {
-        .collapsible-header button::before {
-          transform: rotate(0);
-          top: 0.3rem;
-          left: -0.2rem;
-        }
-
-        .collapsible-subheader {
-          color: var(--colour-primary);
-        }
-      }
-
-      .footnote-details {
-        display: none;
-      }
-
-      .calculations {
-        .card .title {
-          position: relative;
-
-          .inconsistent-flag {
-            padding-right: 0.75rem;
-            position: relative;
-            top: 0.2rem;
-            color: var(--colour-warning);
-
-            &::before {
-              .icon-circle-cross();
-            }
-          }
-
-          .consistent-flag {
-            padding-right: 0.75rem;
-            position: relative;
-            top: 0.2rem;
-            color: var(--colour-primary);
-
-            &::before {
-              .icon-circle-tick();
-            }
-          }
-
-          .unchecked-flag {
-            padding-right: 0.5rem;
-            position: relative;
-            top: 0.2rem;
-
-            &::before {
-              .icon-question();
-            }
-          }
-
-        }
-
-        table.calculation-table {
-          width: 100%;
-          border-collapse: collapse;
-
-          tr.item {
-            td {
-              padding: 0.2rem 0;
-              line-height: 1.8rem;
-
-              &.weight {
-                text-align: center;
-              }
-
-              &.value {
-                text-align: right;
-              }
-            }
-
-            &:not(.calc-fact-link, .total) .concept-name {
-              color: #777;
-            }
-
-            &:not(.calc-fact-link) {
-              td {
-                .text-md();
-
-                &.concept-name {
-                  // Compensate for padding that gets added by button on clickable rows.
-                  padding: 0.3rem;
-                }
-              }
-            }
-
-            &.calc-fact-link {
-              cursor: pointer;
-
-              .concept-name,
-              .value {
-                color: var(--colour-primary);
-
-                button {
-                  .text-md();
-                }
-              }
-            }
-
-            &.linked-highlight,
-            &.calc-fact-link:hover {
-              .linked-highlight-text();
-            }
-
-            &.total td {
-              border-top: solid 1px var(--colour-border-grey);
-              padding-bottom: 1.2rem;
-            }
-          }
-        }
-
-        .calculation-details-link {
-          .inline-button();
-          .text-md();
-        }
-      }
-    }
-
-    .resetable-multiselect {
-      position: relative;
-
-      .reset-multiselect {
-        position: absolute;
-        top: -2.5rem;
-        right: -0.5rem;
-        cursor: pointer;
-        border: none;
-        padding: 0.3rem;
-
-
-        &::after {
-          .icon-close();
-        }
-      }
-    }
-
-    &:not(.no-fact-selected) {
-      .no-fact-overlay {
-        display: none;
-      }
-    }
-
-    &.no-fact-selected {
-      .fact-selected-only {
-        display: none;
-      }
-    }
-
-    &:not(.hidden-fact) {
-      .hidden-fact-tag {
-        display: none;
-      }
-    }
-
-    &:not(.html-hidden-fact) {
-      .html-hidden-fact-tag {
-        display: none;
-      }
-    }
-
-    &.search-mode {
-      #inspector-head {
-        .controls {
-          .search-button {
-            .square-button.primary();
-          }
-        }
-      }
-    }
-
-    &.outline-mode {
-      #inspector-head {
-        .controls {
-          .outline-button {
-            .square-button.primary();
-          }
-        }
-      }
-    }
-
-    &.summary-mode {
-      #inspector-head {
-        .controls {
-          .summary-button {
-            .square-button.primary();
-          }
-        }
-      }
-    }
-
-    .powered-by {
-      .text-sm();
-
-      text-align: center;
-      flex-shrink: 0;
-      background: var(--colour-bg);
-      width: 100%;
-      height: 3rem;
-      margin: 0;
-      box-sizing: border-box;
-      border-top: solid 0.1rem var(--colour-border-grey);
-      position: relative;
-
-      img {
-        box-sizing: border-box;
-        height: 3rem;
-        padding: 0.5rem;
-      }
-
-      .version {
-        position: absolute;
-        top: 0;
-        right: 5px;
-        font-size: small;
-        line-height: 3rem;
-        color: var(--colour-text-light);
-      }
-    }
-
-    &:not(.search-mode) .search-mode-only {
-      display: none;
-    }
-
-    &:not(.outline-mode) .outline-mode-only {
-      display: none;
-    }
-
-    &:not(.summary-mode) .summary-mode-only {
-      display: none;
-    }
-
-    &.search-mode .fact-mode-only,
-    &.summary-mode .fact-mode-only,
-    &.outline-mode .fact-mode-only {
-      display: none;
-    }
-
-    &:not(.footnote-mode) .footnote-mode-only {
-      display: none;
-    }
-
-    &.footnote-mode .footnote-mode-off {
-      display: none;
-    }
-
-    .failed-to-load-mask {
-      display: none;
-    }
-
-    &.failed-to-load .failed-to-load-mask {
-      display: block;
-      background-color: var(--colour-bg-fade);
-      position: absolute;
-      width: 100%;
-      height: 100%;
-    }
-
-    &.search-ready {
-      .search-not-ready-only {
-        display: none;
-      }
-    }
-
-    &:not(.search-ready) {
-      .search-ready-only {
-        display: none;
       }
 
       .search-results {
-        background-color: rgb(0 0 0 / 50%);
+        overflow-y: auto;
+        height: 100%;
+        .panel-indent();
+
+        .search-overlay {
+          transform: translate(-50%, -50%);
+          position: absolute;
+          top: 50%;
+          left: 50%;
+          color: var(--colour-text-light);
+          width: 85%;
+
+          .search-overlay-icon {
+            text-align: center;
+            font-size: 10rem;
+            line-height: normal;
+
+            &::before {
+              .icon-search();
+            }
+          }
+
+          .search-overlay-text {
+            text-align: center;
+            font-size: medium;
+            line-height: normal;
+
+            .title {
+              font-size: x-large;
+              line-height: normal;
+            }
+          }
+        }
+
+
+        .more-results {
+          .clickable();
+
+          padding: 1rem;
+          text-align: center;
+        }
+      } /* search results */
+
+      .outline {
+        overflow-y: auto;
+        height: 100%;
+      }
+
+      .summary {
+        overflow-y: auto;
+        height: 100%;
+      }
+
+      .body {
+        .panel-indent();
+      }
+    } /* inspector body */
+  } /* inspector container */
+
+  .std-label {
+    margin-left: 30px;
+    min-height: 20px;
+    position: relative;
+
+    &::before {
+      color: var(--colour-primary);
+      content: "\2022";
+      position: absolute;
+      left: -20px;
+      font-size: x-large;
+    }
+  }
+
+  dt {
+    font-weight: bold;
+    color: var(--colour-text-title);
+    margin-bottom: 1.4rem;
+    margin-top: 1.4rem;
+  }
+
+  dd {
+    margin-inline-start: 2rem;
+  }
+
+  #concept {
+    margin-top: 20px;
+    font-size: small;
+    min-height: 25px;
+  }
+
+  #dimensions {
+    margin-left: 2rem;
+    margin-right: 2rem;
+    margin-bottom: 1rem;
+
+    .dimension {
+      position: relative;
+      margin: 1.5rem 0 1.5rem 1rem;
+
+      &::before {
+        .icon-dimension();
+
+        color: var(--colour-primary);
+        position: absolute;
+        top: 0;
+        left: -2.3rem;
+        font-size: 120%;
       }
     }
 
-    table.property-table {
-      &:not(.numeric) {
-        table-layout: fixed;
-        width: 100%;
+    .dimension-value {
+      position: relative;
+      margin: 1.5rem 0 1.5rem 3.5rem;
+
+      &::before {
+        .icon-dimension-member();
+
+        position: absolute;
+        color: var(--colour-primary);
+        top: 0;
+        left: -2.3rem;
+        font-size: 120%;
       }
+    }
+  }
 
-      td, th {
-        padding: 0;
-        line-height: 2.6rem;
-      }
+  .inline-button {
+    display: inline;
+    cursor: pointer;
+    color: var(--colour-primary);
+    padding: 0.3rem;
+    border: none;
+  }
 
-      th {
-        width: 90px;
-        text-align: right;
-        padding-right: 30px;
-        color: var(--colour-text-title);
+  .analyse {
+    margin-left: 0.4rem;
+  }
 
-        &.has-tooltip {
-          padding-right: 10px;
-        }
-      }
+  .analyse::before {
+    .icon-graph();
 
-      tr.value {
-        .show-all {
-          color: var(--colour-primary);
-          cursor: pointer;
-        }
+    position: relative;
+    top: 1px;
+  }
 
-        &:not(.truncated) .show-all {
-          display: none;
-        }
+  .inspector-body .tags {
+    position: absolute;
+    top: 1.5rem;
+    right: 0.9rem;
+  }
 
-        &.text-block .expand-text-block {
-          color: var(--colour-primary);
-          cursor: pointer;
+  .target-document-tag {
+    .tag();
+  }
+
+  .hidden-fact-tag,
+  .html-hidden-fact-tag {
+    .tag();
+
+    &.html-hidden-fact-tag {
+      background-color: #c63018;
+    }
+  }
+
+
+  .duplicates {
+    text-align: center;
+    width: 100%;
+    height: 3.2rem;
+    line-height: 3.2rem;
+
+    & > * {
+      vertical-align: middle;
+    }
+
+    .text {
+      margin: 0 5px;
+    }
+
+    .next,
+    .prev {
+      .square-button-bare();
+
+      position: relative;
+      display: inline-block;
+    }
+
+    .prev::before {
+      .icon-chevron-left();
+    }
+
+    .next::before {
+      .icon-chevron-right();
+    }
+  }
+
+  .concept td > div {
+    display: flex;
+
+    span.text {
+      white-space: nowrap;
+      position: relative;
+      flex-shrink: 1;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    span.filler {
+      width: 0.7rem;
+      display: inline-block;
+      flex-shrink: 1000;
+    }
+
+    span.copy-icon {
+      flex-shrink: 0;
+    }
+  }
+
+  .documentation {
+    margin-top: 10px;
+    margin-left: 30px;
+    font-style: italic;
+    font-family: serif;
+  }
+
+  width: 25%;
+  position: absolute;
+  top: var(--top-bar-height);
+  right: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  overflow: hidden;
+  border-left: solid 0.1rem var(--colour-border-grey);
+
+  .inspector-section {
+    padding-left: 0.9rem;
+    padding-right: 0.9rem;
+  }
+
+  .collapsible-section {
+    .collapsible-body {
+      .panel-indent();
+    }
+
+    .collapsible-header {
+      position: relative;
+      padding: 0 0 0.5rem 1.2rem;
+      cursor: pointer;
+      user-select: none;
+      white-space: nowrap;
+      border-bottom: solid 1px var(--colour-border-grey);
+
+      button:first-of-type {
+          .text-md();
+
+          border: none;
+          color: var(--colour-text-title);
+          text-align: left;
+          position: relative;
+          padding: 0.4rem 0.9rem 0.4rem 2.3rem;
 
           &::before {
-            .icon-text-block();
+            .icon-chevron-right();
+
+            font-size: 1.8rem;
+            position: absolute;
+            top: 0.4rem;
+            left: 0;
+            transform: rotate(90deg);
+            transition: all 0.25s ease;
+            display: inline-block;
+          }
+      }
+
+      .collapsible-subheader {
+        user-select: none;
+        font-weight: normal;
+        font-style: italic;
+        font-size: 1.3rem;
+        color: var(--colour-text-form-value);
+      }
+    }
+
+    &.collapsed {
+      .collapsible-header button::before {
+        transform: rotate(0);
+        top: 0.3rem;
+        left: -0.2rem;
+      }
+
+      .collapsible-subheader {
+        color: var(--colour-primary);
+      }
+    }
+
+    .footnote-details {
+      display: none;
+    }
+
+    .calculations {
+      .card .title {
+        position: relative;
+
+        .inconsistent-flag {
+          padding-right: 0.75rem;
+          position: relative;
+          top: 0.2rem;
+          color: var(--colour-warning);
+
+          &::before {
+            .icon-circle-cross();
+          }
+        }
+
+        .consistent-flag {
+          padding-right: 0.75rem;
+          position: relative;
+          top: 0.2rem;
+          color: var(--colour-primary);
+
+          &::before {
+            .icon-circle-tick();
+          }
+        }
+
+        .unchecked-flag {
+          padding-right: 0.5rem;
+          position: relative;
+          top: 0.2rem;
+
+          &::before {
+            .icon-question();
+          }
+        }
+
+      }
+
+      table.calculation-table {
+        width: 100%;
+        border-collapse: collapse;
+
+        tr.item {
+          td {
+            padding: 0.2rem 0;
+            line-height: 1.8rem;
+
+            &.weight {
+              text-align: center;
+            }
+
+            &.value {
+              text-align: right;
+            }
+          }
+
+          &:not(.calc-fact-link, .total) .concept-name {
+            color: #777;
+          }
+
+          &:not(.calc-fact-link) {
+            td {
+              .text-md();
+
+              &.concept-name {
+                // Compensate for padding that gets added by button on clickable rows.
+                padding: 0.3rem;
+              }
+            }
+          }
+
+          &.calc-fact-link {
+            cursor: pointer;
+
+            .concept-name,
+            .value {
+              color: var(--colour-primary);
+
+              button {
+                .text-md();
+              }
+            }
+          }
+
+          &.linked-highlight,
+          &.calc-fact-link:hover {
+            .linked-highlight-text();
+          }
+
+          &.total td {
+            border-top: solid 1px var(--colour-border-grey);
+            padding-bottom: 1.2rem;
           }
         }
       }
 
-      td {
-        overflow: clip visible;
-        text-overflow: ellipsis;
-        color: var(--colour-text-form-value);
-      }
-
-      tr.uri > td {
-        white-space: nowrap;
-      }
-
-      &.numeric td {
-        text-align: right;
+      .calculation-details-link {
+        .inline-button();
+        .text-md();
       }
     }
   }
 
-  .fact-link {
-    cursor: pointer;
-    color: var(--colour-primary);
+  .resetable-multiselect {
+    position: relative;
 
-    &:hover {
-      outline: solid 0.125em var(--colour-linked-fact);
-      outline-offset: 0.0625em;
+    .reset-multiselect {
+      position: absolute;
+      top: -2.5rem;
+      right: -0.5rem;
+      cursor: pointer;
+      border: none;
+      padding: 0.3rem;
+
+
+      &::after {
+        .icon-close();
+      }
     }
   }
 
-  .fact-list {
-    .fact-list-item {
-      .block-list-item();
+  &:not(.no-fact-selected) {
+    .no-fact-overlay {
+      display: none;
+    }
+  }
 
-      .select-icon {
-        float: right;
-        .square-button();
-        .clickable();
+  &.no-fact-selected {
+    .fact-selected-only {
+      display: none;
+    }
+  }
 
-        &:first-of-type {
-          margin-left: 0.5rem;
+  &:not(.hidden-fact) {
+    .hidden-fact-tag {
+      display: none;
+    }
+  }
+
+  &:not(.html-hidden-fact) {
+    .html-hidden-fact-tag {
+      display: none;
+    }
+  }
+
+  &.search-mode {
+    #inspector-head {
+      .controls {
+        .search-button {
+          .square-button.primary();
         }
+      }
+    }
+  }
+
+  &.outline-mode {
+    #inspector-head {
+      .controls {
+        .outline-button {
+          .square-button.primary();
+        }
+      }
+    }
+  }
+
+  &.summary-mode {
+    #inspector-head {
+      .controls {
+        .summary-button {
+          .square-button.primary();
+        }
+      }
+    }
+  }
+
+  .powered-by {
+    .text-sm();
+
+    text-align: center;
+    flex-shrink: 0;
+    background: var(--colour-bg);
+    width: 100%;
+    height: 3rem;
+    margin: 0;
+    box-sizing: border-box;
+    border-top: solid 0.1rem var(--colour-border-grey);
+    position: relative;
+
+    img {
+      box-sizing: border-box;
+      height: 3rem;
+      padding: 0.5rem;
+    }
+
+    .version {
+      position: absolute;
+      top: 0;
+      right: 5px;
+      font-size: small;
+      line-height: 3rem;
+      color: var(--colour-text-light);
+    }
+  }
+
+  &:not(.search-mode) .search-mode-only {
+    display: none;
+  }
+
+  &:not(.outline-mode) .outline-mode-only {
+    display: none;
+  }
+
+  &:not(.summary-mode) .summary-mode-only {
+    display: none;
+  }
+
+  &.search-mode .fact-mode-only,
+  &.summary-mode .fact-mode-only,
+  &.outline-mode .fact-mode-only {
+    display: none;
+  }
+
+  &:not(.footnote-mode) .footnote-mode-only {
+    display: none;
+  }
+
+  &.footnote-mode .footnote-mode-off {
+    display: none;
+  }
+
+  .failed-to-load-mask {
+    display: none;
+  }
+
+  &.failed-to-load .failed-to-load-mask {
+    display: block;
+    background-color: var(--colour-bg-fade);
+    position: absolute;
+    width: 100%;
+    height: 100%;
+  }
+
+  &.search-ready {
+    .search-not-ready-only {
+      display: none;
+    }
+  }
+
+  &:not(.search-ready) {
+    .search-ready-only {
+      display: none;
+    }
+
+    .search-results {
+      background-color: rgb(0 0 0 / 50%);
+    }
+  }
+
+  table.property-table {
+    &:not(.numeric) {
+      table-layout: fixed;
+      width: 100%;
+    }
+
+    td, th {
+      padding: 0;
+      line-height: 2.6rem;
+    }
+
+    th {
+      width: 90px;
+      text-align: right;
+      padding-right: 30px;
+      color: var(--colour-text-title);
+
+      &.has-tooltip {
+        padding-right: 10px;
+      }
+    }
+
+    tr.value {
+      .show-all {
+        color: var(--colour-primary);
+        cursor: pointer;
+      }
+
+      &:not(.truncated) .show-all {
+        display: none;
+      }
+
+      &.text-block .expand-text-block {
+        color: var(--colour-primary);
+        cursor: pointer;
 
         &::before {
-          .icon-select();
+          .icon-text-block();
         }
       }
+    }
 
+    td {
+      overflow: clip visible;
+      text-overflow: ellipsis;
+      color: var(--colour-text-form-value);
+    }
+
+    tr.uri > td {
+      white-space: nowrap;
+    }
+
+    &.numeric td {
+      text-align: right;
+    }
+  }
+}
+
+.fact-link {
+  cursor: pointer;
+  color: var(--colour-primary);
+
+  &:hover {
+    outline: solid 0.125em var(--colour-linked-fact);
+    outline-offset: 0.0625em;
+  }
+}
+
+.fact-list {
+  .fact-list-item {
+    .block-list-item();
+
+    .select-icon {
+      float: right;
+      .square-button();
+      .clickable();
+
+      &:first-of-type {
+        margin-left: 0.5rem;
+      }
+
+      &::before {
+        .icon-select();
+      }
+    }
+
+    .title {
+      color: var(--colour-text-title);
+      font-weight: bold;
+    }
+
+    .dimension {
+      color: var(--colour-text);
+      margin: 0.6rem 0;
+    }
+
+    .datatype {
+      color: var(--colour-text);
+      margin: 0.6rem 0;
+      font-style: italic;
+    }
+
+    .hidden {
+      .tag();
+    }
+
+    &.selected {
       .title {
-        color: var(--colour-text-title);
         font-weight: bold;
       }
 
       .dimension {
         color: var(--colour-text);
-        margin: 0.6rem 0;
       }
+    }
 
-      .datatype {
-        color: var(--colour-text);
-        margin: 0.6rem 0;
-        font-style: italic;
-      }
+  }
+}
 
-      .hidden {
-        .tag();
-      }
 
-      &.selected {
-        .title {
-          font-weight: bold;
-        }
+.dialog-mask {
+  background-color: var(--colour-bg-fade);
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  display: none;
+}
 
-        .dimension {
-          color: var(--colour-text);
-        }
-      }
+.popup-content {
+  display: none;
+}
 
+.copy-icon {
+  color: var(--colour-primary);
+  border-radius: 0.3rem;
+
+  &:active {
+    background-color: var(--colour-primary);
+    color: var(--colour-bg);
+  }
+
+  &::before {
+    .icon-clipboard();
+
+    cursor: pointer;
+  }
+}
+
+.has-tooltip {
+  white-space: nowrap;
+  
+  & > * {
+    vertical-align: middle;
+  }
+
+  .tooltip-icon {
+    .inline-button();
+
+    cursor: help;
+    margin-left: -0.3rem;
+    vertical-align: middle;
+
+    &::after {
+      content: "\24d8"; 
     }
   }
 
+  button + .tooltip-icon {
+    margin-left: -1rem;
+  }
+}
 
-  .dialog-mask {
-    background-color: var(--colour-bg-fade);
-    position: fixed;
-    inset: 0;
-    z-index: 10;
+.tooltip {
+  position: fixed;
+  visibility: hidden;
+  transition: all 0.5s ease;
+  background-color: var(--colour-bg);
+  z-index: 1;
+  border: solid 0.1rem var(--colour-border-grey);
+  border-radius: 0.4rem;
+  padding: 0.8rem;
+  box-shadow: rgb(0 0 0 / 30%) 0.2rem 0.2rem 0.2rem;
+  font-weight: normal;
+  opacity: 0;
+  cursor: default;
+  color: var(--colour-text);
+  text-align: left;
+
+  &.show,
+  &.hover-show {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.5s ease;
+  }
+
+  &.with-glossary-link .glossary-link {
+    display: block;
+  }
+
+  .glossary-link {
+    margin-top: 0.8rem;
+    font-size: smaller;
     display: none;
   }
+}
 
-  .popup-content {
-    display: none;
+.fact-value {
+  &.fact-value-invalid {
+    font-style: italic;
+    color: #f00;
   }
 
-  .copy-icon {
-    color: var(--colour-primary);
-    border-radius: 0.3rem;
-
-    &:active {
-      background-color: var(--colour-primary);
-      color: var(--colour-bg);
-    }
-
-    &::before {
-      .icon-clipboard();
-
-      cursor: pointer;
-    }
+  &.fact-value-nil {
+    font-style: italic;
   }
 
-  .has-tooltip {
-    white-space: nowrap;
-    
-    & > * {
-      vertical-align: middle;
-    }
-
-    .tooltip-icon {
-      .inline-button();
-
-      cursor: help;
-      margin-left: -0.3rem;
-      vertical-align: middle;
-
-      &::after {
-        content: "\24d8"; 
-      }
-    }
-
-    button + .tooltip-icon {
-      margin-left: -1rem;
-    }
-  }
-
-  .tooltip {
-    position: fixed;
-    visibility: hidden;
-    transition: all 0.5s ease;
-    background-color: var(--colour-bg);
-    z-index: 1;
-    border: solid 0.1rem var(--colour-border-grey);
-    border-radius: 0.4rem;
-    padding: 0.8rem;
-    box-shadow: rgb(0 0 0 / 30%) 0.2rem 0.2rem 0.2rem;
-    font-weight: normal;
-    opacity: 0;
-    cursor: default;
-    color: var(--colour-text);
-    text-align: left;
-
-    &.show,
-    &.hover-show {
-      visibility: visible;
-      opacity: 1;
-      transition: opacity 0.5s ease;
-    }
-
-    &.with-glossary-link .glossary-link {
-      display: block;
-    }
-
-    .glossary-link {
-      margin-top: 0.8rem;
-      font-size: smaller;
-      display: none;
-    }
-  }
-
-  .fact-value {
-    &.fact-value-invalid {
-      font-style: italic;
-      color: #f00;
-    }
-
-    &.fact-value-nil {
-      font-style: italic;
-    }
-
-    .measure {
-      border-bottom: 1px dotted @colour-text-form-value;
-      cursor: help;
-    }
+  .measure {
+    border-bottom: 1px dotted @colour-text-form-value;
+    cursor: help;
   }
 }


### PR DESCRIPTION
#### Reason for change

`<button>` elements have their own styling applied by user agent stylesheets. This overrides the default font used elsewhere in the viewer (see #821), leading to inconsistent fonts.

Fixes #821

#### Description of change

Specify our standard default font for `<button>` elements. I've also removed the `#ixv` scope of all inspector CSS rules. This is unnecessary, and dates back to _very_ early version of the viewer that didn't use iframes.

#### Steps to Test

See examples on #821. Confirm that font is now consistent.

**review**:
@Arelle/arelle
@paulwarren-wk
