### PR TITLE
Avoid using hidden table cells as wrapper nodes

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -261,11 +261,12 @@ export class Viewer {
         }
 
         /* Is the element the only significant content within a <td> or <th> ? If
-         * so, use that as the wrapper element. */
+         * so, use that as the wrapper element.
+         * Check for 'display: table-cell' to avoid using hidden cells */
         const tableNode = domNode.closest("td,th");
         const nodes = [];
         const innerText = $(domNode).text();
-        if (tableNode !== null && innerText.length > 0) {
+        if (tableNode !== null && getComputedStyle(tableNode).display === 'table-cell' && innerText.length > 0) {
             // Use indexOf rather than a single regex because innerText may
             // be too long for the regex engine 
             const outerText = $(tableNode).text();


### PR DESCRIPTION
#### Reason for change

Tags being mislabelled as "concealed facts".

Fixes #815

#### Description of change

We try to use table cells as wrapper nodes where possible, because it makes fact highlighting neater. Some reports are using table cells with "display: contents" in order to get the semantics of tables (required for some ESEF reports) without interfering with layout. Attempting to use these as wrapper nodes will never give us what we want, and leads to other problems, as described in #815.

#### Steps to Test

Confirm that facts on test doc on #815 are no longer mislabelled as concealed.

**review**:
@Arelle/arelle
@paulwarren-wk
