### PR TITLE
Update user guide link to actual user guide

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -32,7 +32,7 @@ export const STORAGE_APP_LANGUAGE = "ixbrl-viewer-app-language";
 export const STORAGE_THEME = "ixbrl-viewer-theme";
 export const STORAGE_HIGHLIGHT_FACTS = "ixbrl-viewer-highlight-all-facts";
 export const STORAGE_HOME_LINK_QUERY = "ixbrl-viewer-home-link-query";
-export const USER_GUIDE_URL = "https://arelle-ixbrl-viewer.readthedocs.io/";
+export const USER_GUIDE_URL = "https://arelle-ixbrl-viewer.readthedocs.io/en/latest/user_guides/user_guide.html";
 
 /* 
  * Takes a moment.js oject and converts it to a human readable date, or date


### PR DESCRIPTION
I'm linking to the latest version instead of the current viewer's version because I expect user guide coverage to grow, and I'd prefer people see the version of the guide with the most coverage and only small discrepancies (hopefully).

**review**:
@Arelle/arelle
@paulwarren-wk
