### PR TITLE
Add feature to disable calculation 1.1 mode option

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -3,7 +3,7 @@
 import $ from 'jquery'
 import i18next from 'i18next';
 import jqueryI18next from 'jquery-i18next';
-import {formatNumber, wrapLabel, truncateLabel, runGenerator, SHOW_FACT, HIGHLIGHT_COLORS, viewerUniqueId, GLOSSARY_URL, FEATURE_HOME_LINK_URL, FEATURE_HOME_LINK_LABEL, FEATURE_SEARCH_ON_STARTUP, FEATURE_HIGHLIGHT_FACTS_ON_STARTUP, STORAGE_APP_LANGUAGE, STORAGE_HIGHLIGHT_FACTS, STORAGE_HOME_LINK_QUERY} from "./util.js";
+import {formatNumber, wrapLabel, truncateLabel, runGenerator, SHOW_FACT, HIGHLIGHT_COLORS, viewerUniqueId, GLOSSARY_URL, FEATURE_HOME_LINK_URL, FEATURE_HOME_LINK_LABEL, FEATURE_SEARCH_ON_STARTUP, FEATURE_HIGHLIGHT_FACTS_ON_STARTUP, STORAGE_APP_LANGUAGE, STORAGE_HIGHLIGHT_FACTS, STORAGE_HOME_LINK_QUERY, FEATURE_HIDE_CALCULATION_MODE_OPTION} from "./util.js";
 import { ReportSearch } from "./search.js";
 import { IXBRLChart } from './chart.js';
 import { ViewerOptions } from './viewerOptions.js';
@@ -304,9 +304,8 @@ export class Inspector {
             }
 
             // Options
-            this._optionsMenu.addLabel(i18next.t("menu.options"));
-
-            if (this._reportSet.usesCalculations()) {
+            if (this._reportSet.usesCalculations() && !this._iv.isFeatureEnabled(FEATURE_HIDE_CALCULATION_MODE_OPTION)) {
+                this._optionsMenu.addLabel(i18next.t("menu.options"));
                 this._optionsMenu.addCheckboxItem(i18next.t("calculation.useCalculations11"), (useCalc11) => this.setCalculationMode(useCalc11), "calculation-mode", "select-language", this._useCalc11);
             }
         }

--- a/iXBRLViewerPlugin/viewer/src/js/util.js
+++ b/iXBRLViewerPlugin/viewer/src/js/util.js
@@ -25,6 +25,7 @@ export const FEATURE_SUPPORT_LINK = 'support_link';
 export const FEATURE_SURVEY_LINK = 'survey_link';
 export const FEATURE_SEARCH_ON_STARTUP = 'search_on_startup';
 export const FEATURE_HIGHLIGHT_FACTS_ON_STARTUP = 'highlight_facts_on_startup';
+export const FEATURE_HIDE_CALCULATION_MODE_OPTION = 'hide_calculation_mode_option';
 
 export const IXBRL_VIEWER_DATASET_PREFIX = 'ixbrlViewer';
 


### PR DESCRIPTION
#### Reason for change

FRC suggested that calculation mode switch was confusing.

#### Description of change

Adds a feature called `hide_calculation_mode_option` that can be specified to remove the Calculations 1.1 option from the options menu.

This can be specified in the usual ways, including via the runtime config

#### Steps to Test

Open a filing with calculations, confirm that Calc 1.1 option is present on the menu.

Add:

```json
    "features": {
        "hide_calculation_mode_option": true
    },
```

to `ixbrlviewer.config.json`.

Reload viewer and confirm that Calc 1.1 option is no longer present.

**review**:
@Arelle/arelle
@paulwarren-wk
