### PR TITLE
Enhancement: Use symbols in UTR for all units that have them defined (not just currencies)

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/unit.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.js
@@ -20,11 +20,15 @@ function measureLabel(report, measure) {
     }
     // Pick symbol from UTR ...
     const utrEntry = utr.get(qname);
-    if (utrEntry !== undefined && utrEntry.symbol !== undefined) {
-        // ... but disambiguate "$" symbol
-        return utrEntry.symbol == '$' ? `${qname.localname} $` : utrEntry.symbol;
+    if (utrEntry !== undefined) {
+        if (utrEntry.symbol !== undefined) {
+            // ... but disambiguate "$" symbol
+            return utrEntry.symbol == '$' ? `${qname.localname} $` : utrEntry.symbol;
+        }
+        // Fall back to name
+        return utrEntry.name;
     }
-    // Otherwise fallback to unitId 
+    // Otherwise the measure is not in the UTR so fallback to unitId 
     if (measure.includes(':')) {
         return measure.split(':')[1];
     }

--- a/iXBRLViewerPlugin/viewer/src/js/unit.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.js
@@ -12,18 +12,19 @@ import { utr } from "./utr";
 function measureLabel(report, measure) {
     const qname = report.qname(measure);
     if (qname.namespace === NAMESPACE_ISO4217) {
-        // Prefer a name from our own i18n resources
+        // Prefer a name from our own i18n resources for currencies
         const keyi18n = `currencies:unitFormat${qname.localname}`;
         if (i18next.exists(keyi18n)) {
             return i18next.t(keyi18n);
         }
-        // Fall back on symbol from UTR ...
-        const utrEntry = utr.get(qname);
-        if (utrEntry !== undefined) {
-            // ... but disambiguate "$" symbol
-            return utrEntry.symbol == '$' ? `${qname.localname} $` : utrEntry.symbol;
-        }
     }
+    // Pick symbol from UTR ...
+    const utrEntry = utr.get(qname);
+    if (utrEntry !== undefined && utrEntry.symbol !== undefined) {
+        // ... but disambiguate "$" symbol
+        return utrEntry.symbol == '$' ? `${qname.localname} $` : utrEntry.symbol;
+    }
+    // Otherwise fallback to unitId 
     if (measure.includes(':')) {
         return measure.split(':')[1];
     }

--- a/iXBRLViewerPlugin/viewer/src/js/unit.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.test.js
@@ -11,6 +11,7 @@ var testReportData = {
         "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
         "utr": "http://www.xbrl.org/2009/utr",
+        "xbrli": "http://www.xbrl.org/2003/instance",
     },
     "facts": {},
 };
@@ -72,21 +73,39 @@ describe("Unit label", () => {
         expect(unit.label()).toEqual('SGD $');
     });
 
+    test("Unit label - UTR currency without symbol falls back to name", () => {
+        var unit = new Unit(testReport(), 'iso4217:YER');
+        expect(unit.label()).toEqual('Yemeni rial');
+    });
+
+    test("Unit label - UTR currency without symbol falls back to name", () => {
+        var unit = new Unit(testReport(), 'iso4217:XAU');
+        expect(unit.label()).toEqual('Gold');
+    });
+
     test("Unit label - unknown", () => {
         var unit = new Unit(testReport(), 'iso4217:ZZZZ');
         expect(unit.label()).toEqual('ZZZZ');
     });
+
     test("Unit label - UTR non-currency symbol used", () => {
         var unit = new Unit(testReport(), 'utr:m3');
         expect(unit.label()).toEqual('m³');
     });
+
     test("Unit label - UTR non-currency symbol used", () => {
         var unit = new Unit(testReport(), 'utr:sqkm');
         expect(unit.label()).toEqual('km²');
     });
+
     test("Unit label - UTR non-currency symbol used", () => {
         var unit = new Unit(testReport(), 'utr:F');
         expect(unit.label()).toEqual('°F');
+    });
+
+    test("Unit label - UTR non-currency without symbol falls back to name", () => {
+        var unit = new Unit(testReport(), 'xbrli:shares');
+        expect(unit.label()).toEqual('Share');
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/unit.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/unit.test.js
@@ -10,6 +10,7 @@ var testReportData = {
         "eg": "http://www.example.com",
         "iso4217": NAMESPACE_ISO4217,
         "e": "http://example.com/entity",
+        "utr": "http://www.xbrl.org/2009/utr",
     },
     "facts": {},
 };
@@ -74,6 +75,18 @@ describe("Unit label", () => {
     test("Unit label - unknown", () => {
         var unit = new Unit(testReport(), 'iso4217:ZZZZ');
         expect(unit.label()).toEqual('ZZZZ');
+    });
+    test("Unit label - UTR non-currency symbol used", () => {
+        var unit = new Unit(testReport(), 'utr:m3');
+        expect(unit.label()).toEqual('m³');
+    });
+    test("Unit label - UTR non-currency symbol used", () => {
+        var unit = new Unit(testReport(), 'utr:sqkm');
+        expect(unit.label()).toEqual('km²');
+    });
+    test("Unit label - UTR non-currency symbol used", () => {
+        var unit = new Unit(testReport(), 'utr:F');
+        expect(unit.label()).toEqual('°F');
     });
 });
 

--- a/iXBRLViewerPlugin/viewer/src/js/utr.js
+++ b/iXBRLViewerPlugin/viewer/src/js/utr.js
@@ -20,7 +20,7 @@ class UTR {
         if (u === undefined) {
             return undefined;
         }
-        return new UTREntry(u.s ?? u.n, u.n)
+        return new UTREntry(u.s ?? undefined, u.n)
     }
 }
 

--- a/iXBRLViewerPlugin/viewer/src/js/utr.js
+++ b/iXBRLViewerPlugin/viewer/src/js/utr.js
@@ -20,7 +20,7 @@ class UTR {
         if (u === undefined) {
             return undefined;
         }
-        return new UTREntry(u.s ?? undefined, u.n)
+        return new UTREntry(u.s, u.n)
     }
 }
 


### PR DESCRIPTION
#### Reason for change
I noticed that the measure labels (units) displayed in the viewer used the symbols from the UTR for currencies (so £ is displayed instead of GBP) but the symbols for other measures were not.

If you want to report an area using square meters, you need to use a measure of `utr:sqm` in your unit, which ixbrl-viewer will display as "sqm" with a tool tip of "Square metre". ixbrl-viewer should be displaying "m²" with a tool tip of "Square metre"

#### Description of change
Previously, currencies would use their symbol for their measure label but not other units. Shuffle the code around so that now all units will use their symbol if they have one defined and, if not, fall back to using their unit id as before.

In `utr.js`, which defines objects `UTR` and `UTREntry`, if a symbol was undefined for a given `UTREntry`, the name was used as the symbol. This didn't feel right, so I've moved the behaviour of "fallback on the name" to the only caller in `unit.js`: `measureLabel()` now handles all decisions about what and when to fallback to during the hunt for a suitable label for a measure.

Added a few tests to make sure this behaviour works and there are no regressions on the existing behaviour.
#### Steps to Test
Create an XBRL report that uses units from the UTR that have symbols that are different to their unitId (e.g. Fahrenheit, sqkm) and see that previously Arelle displayed the unitId and now it displays the symbol. The tool tip (name) is unchanged.

**review**:
@Arelle/arelle
@paulwarren-wk
