### PR TITLE
Remove User Guide link from dropdown

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -310,10 +310,6 @@ export class Inspector {
             }
         }
         let helpLinks = {}
-        let guideLinkUrl = this._iv.getGuideLinkUrl();
-        if (guideLinkUrl) {
-            helpLinks[i18next.t("menu.userGuide")] = guideLinkUrl;
-        }
         let supportLinkUrl = this._iv.getSupportLinkUrl();
         if (supportLinkUrl) {
             helpLinks[i18next.t("menu.contactUs")] = supportLinkUrl;


### PR DESCRIPTION
#### Reason for change
"User Guide" link is duplicated in toolbar and dropdown menu.

#### Description of change
Remove dropdown link in favor of more discoverable toolbar link.

#### Steps to Test
CI

**review**:
@Arelle/arelle
@paulwarren-wk
