### PR TITLE
Python 3.13 Support

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -19,7 +19,7 @@ jobs:
           cache: 'pip'
           cache-dependency-path: '**/requirements-docs.txt'
           check-latest: true
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -22,7 +22,7 @@ jobs:
           - '20'
           - '22'
         python-version:
-          - '3.12'
+          - '3.13'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: string
       python_version:
-        default: '3.12'
+        default: '3.13'
         description: 'Python version to use'
         required: false
         type: string
@@ -21,7 +21,7 @@ on:
         required: true
         type: string
       python_version:
-        default: '3.12'
+        default: '3.13'
         description: 'Python version to use'
         required: true
         type: string

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,6 +23,7 @@ jobs:
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 python:
   install:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Need help with the Arelle iXBRL Viewer? Go check out [our documentation][read-th
 
 ## Installation
 
-The Python portion of this repo is developed using Python 3.12.
+The Python portion of this repo is developed using Python 3.13.
 
 1. Clone the [iXBRL Viewer git repository][ixbrlviewer-github].
 2. Download and install [Arelle][arelle-download]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,11 +19,11 @@ classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
     'Programming Language :: Python :: 3',
-    
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Operating System :: OS Independent',
     'Topic :: Text Processing :: Markup :: XML'
 ]
@@ -69,7 +69,7 @@ write_to = "iXBRLViewerPlugin/_version.py"
 [tool.mypy]
 # Warn when a # type: ignore comment does not specify any error codes
 enable_error_code = "ignore-without-code"
-python_version = "3.12"
+python_version = "3.13"
 show_error_codes = true
 strict = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, lint, typing
+envlist = py39, py310, py311, py312, py313, lint, typing
 isolated_build = True
 skip_missing_interpreters = False
 
@@ -8,7 +8,8 @@ python =
   3.9: py39
   3.10: py310
   3.11: py311
-  3.12: py312, lint, typing
+  3.12: py312
+  3.13: py313, lint, typing
 
 [testenv]
 allowlist_externals = pytest


### PR DESCRIPTION
#### Reason for change
https://github.com/Arelle/Arelle/pull/1615 added Python 3.13 support to Arelle. We should update our ixbrl-viewer builds to use it.

#### Description of change
* Run tests against Python 3.13.
* List Python 3.13 support in the Python Package.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
