### PR TITLE
Improved dark mode for multiple documents/tabs

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/less/tabs.less
+++ b/iXBRLViewerPlugin/viewer/src/less/tabs.less
@@ -5,7 +5,7 @@
 .tab-area {
   .clearfix();
 
-  background-color: #e3e3e3;
+  background-color: var(--colour-bg-selected);
   width: 100%;
   box-sizing: border-box;
   border-bottom: solid 0.1rem var(--colour-border-grey);
@@ -15,8 +15,8 @@
     float: left;
     padding: 1.2rem;
     cursor: pointer;
-    color: #444;
-    border: solid 0.1rem #cbcbcb;
+    color: var(--colour-text-title);
+    border: solid 0.1rem var(--colour-border-grey);
     border-radius: 0.6rem 0.6rem 0 0;
     margin-bottom: -0.1rem;
     flex-shrink: 1;
@@ -30,7 +30,7 @@
       padding: 1.2rem;
       border-bottom-color: var(--colour-bg);
       background-color: var(--colour-bg);
-      border-top: solid 0.4rem #0085e6;
+      border-top: solid 0.4rem var(--colour-primary);
     }
 
     &:not(.active) {


### PR DESCRIPTION
#### Reason for change
Dark mode color styling missing for tabs that appear with multiple documents.

#### Before:
![Screenshot 2025-05-13 at 11 04 34 AM](https://github.com/user-attachments/assets/c25fd9b8-cfa3-4242-8ede-6b8ffb1e5502)

#### After:
![Screenshot 2025-05-13 at 11 06 31 AM](https://github.com/user-attachments/assets/d6473389-21f9-440d-b9ac-5ca1b333d9ec)
![Screenshot 2025-05-13 at 11 06 40 AM](https://github.com/user-attachments/assets/a1fbc897-e06f-4a91-a354-8e1d1569f9be)


**review**:
@Arelle/arelle
@paulwarren-wk
