### PR TITLE
Update Nodejs LTS Versions

### DIFF
--- a/.github/workflows/node-tests.yml
+++ b/.github/workflows/node-tests.yml
@@ -19,9 +19,9 @@ jobs:
           - ubuntu-24.04
           - windows-2022
         node-version:
-          - '18'
           - '20'
           - '22'
+          - '24'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/puppeteer.yml
+++ b/.github/workflows/puppeteer.yml
@@ -18,9 +18,9 @@ jobs:
           - ubuntu-24.04
           - windows-2022
         node-version:
-          - '18'
           - '20'
           - '22'
+          - '24'
         python-version:
           - '3.13'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       node_version:
-        default: '22'
+        default: '24'
         description: 'Node version to use'
         required: false
         type: string
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       node_version:
-        default: '22'
+        default: '24'
         description: 'Node version to use'
         required: true
         type: string


### PR DESCRIPTION
#### Reason for change
Node 24 was released and version 18 is now end-of-life.

#### Description of change
Update tests and build to use latest LTS node release.

#### Steps to Test
* CI

**review**:
@Arelle/arelle
@paulwarren-wk
