### PR TITLE
Refresh search on language change

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -442,6 +442,7 @@ export class Inspector {
         this.buildHighlightKey();
         this.buildUserGuideLink();
         this.update();
+        this.search();
     }
 
     inspectorMode(mode, toggle) {


### PR DESCRIPTION
#### Reason for change
Some text in the search pane doesn't update immediately upon language switch. 

#### Description of change
Refresh the search pane by performing the search function when language is switched.

#### Steps to Test
With search results open, change language. Ensure "Showing X of Y" and "Hidden Fact" text changes to the translated text immediately.

**review**:
@Arelle/arelle
@paulwarren-wk
