### PR TITLE
Python Package Improvements: Arelle Viewer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ ixbrl-viewer = "iXBRLViewerPlugin:load_plugin_url"
 platforms = ["any"]
 
 [tool.setuptools.packages.find]
+include = ["iXBRLViewerPlugin*"]
 namespaces = false
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "ixbrl-viewer"
 dynamic = ['version']
 readme = "README.md"
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 description = "The Arelle iXBRL Viewer allows iXBRL reports to be viewed interactively in a web browser."
 authors = [
     {name = "arelle.org", email = "support@arelle.org"}
@@ -16,7 +16,6 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: End Users/Desktop',
     'Intended Audience :: Developers',
-    'License :: OSI Approved :: Apache Software License',
     'Natural Language :: English',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3.9',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,6 @@ platforms = ["any"]
 
 [tool.setuptools.packages.find]
 include = ["iXBRLViewerPlugin*"]
-namespaces = false
 
 [tool.setuptools_scm]
 tag_regex = "^(?:[\\w-]+-?)?(?P<version>[vV]?\\d+(?:\\.\\d+){0,2}[^\\+]*)(?:\\+.*)?$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=69,<81", "wheel~=0.42", "setuptools_scm[toml]~=8.0"]
+requires = ["setuptools>=73,<81", "wheel~=0.45", "setuptools_scm[toml]~=8.3"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
#### Reason for change
Primary reason is that we are publishing our tests directory as a top level import. Folks who are installing the package don't want this.

```sh
> pip install ixbrl-viewer[arelle,dev]
> python -c "from tests.unit_tests.iXBRLViewerPlugin.test_iXBRLViewer import TestNamespaceMap;print(TestNamespaceMap.__name__)"

TestNamespaceMap
```

#### Description of change
* Update deprecated license config.
* Exclude tests from top level package imports.
* Resolve build warnings related to setuptools_scm including modules in directories without a Python init file.

#### Steps to Test
* [x] make sure package still works.
* [x] make sure tests are no longer importable.

**review**:
@Arelle/arelle
@paulwarren-wk
