### PR TITLE
Add additional exclusions for untagged dates/numbers

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/number-matcher.js
+++ b/iXBRLViewerPlugin/viewer/src/js/number-matcher.js
@@ -90,6 +90,10 @@ const note = 'note' + ws + '\\d{1,3}';
 const level = 'level' + ws + '\\d{1,3}';
 const page = 'page' + ws + '\\d{1,3}';
 const tier = 'tier' + ws + '\\d{1,3}';
+const act = 'act' + ws + 'of' + ws + year; // e.g. 'SECURITIES EXCHANGE ACT OF 1934'
+// Note that this is a superset of "isoDate" but "dateMatch" appears before "do_not_want" so it won't exclude ISO dates.
+const phone_number = '\\d+-\\d+[-\\d]*'    // e.g. 275-3125. Also covers employer number (e.g. 47-2509828). 
+const form_name = '(?:10|8)-(?:k|q)'       // e.g. '10-K'
 
 const months_ended = r_or([number_word, '\\d+']) + ws + 'months ended';
 
@@ -98,7 +102,7 @@ const month_day_year = month_num + '/' + day_with_0 + '/' + year;
 const month_year = month_num + '/\\d\\d';
 
 const do_not_want = r_or([section, topic, form, asc, item, rule, note, level, page,
-                    tier, months_ended, month_day_year, month_year]);
+                    tier, act, phone_number, form_name, months_ended, month_day_year, month_year]);
 
 const number_separator = r_or([r_maybe(ws + hyphen + ws), ws]);
 const number_word_string = number_word + r_zero_or_more(number_separator + number_word);

--- a/iXBRLViewerPlugin/viewer/src/js/number-matcher.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/number-matcher.test.js
@@ -112,12 +112,16 @@ describe("Number match replace", () => {
         var numbers = [
             [ 'Sept 20th, 2019', '[[Sept 20th, 2019]]' ],
             [ 'abcd 37 abcd', 'abcd [[37]] abcd' ],
+            [ '2010-01-01', '[[2010-01-01]]' ],
             // Test "do not want" filtering
             [ 'abcd topic 37 abcd', 'abcd topic 37 abcd' ],
             [ 'abcd topic 37 93 abcd', 'abcd topic 37 [[93]] abcd' ],
             [ 'section 123(a)', 'section 123(a)' ],
             [ 'section 123a', 'section 123a' ],
             [ 'section 123', 'section 123' ],
+            [ 'securities exchange act of 1934', 'securities exchange act of 1934' ],
+            [ '10-K', '10-K' ],
+            [ '274-3125', '274-3125' ],
             // Doesn't match due to end guard
             [ '401(k)', '401(k)' ],
             [ 'N RM100', 'N [[RM100]]' ],


### PR DESCRIPTION
#### Reason for change

Feedback from users: various numbers/dates on the cover page of a typical SEC report were being flagged as untagged, even if they were part of a tag.

<img width="690" height="175" alt="image" src="https://github.com/user-attachments/assets/a4b5e790-d624-4244-ab53-b45bf08edab8" />

e.g. the second part of the phone number and they employer identification number. 

These were treated as untagged as although "275-3125" is tagged, the numbers "275" and "3125" are not complete tags individually.

#### Description of change

Additional exclusions added to numbers that will be ignored:

* Strings containing a mix of numbers and dashes.
* The strings 10-K, 10-Q, 8-K, 8-Q
* Years appearing as the string "Act Of YYYY"

There are still plenty of cover page false positives, but it's not obvious to me how to filter them out further:

<img width="1253" height="836" alt="image" src="https://github.com/user-attachments/assets/779ae61c-db1c-4e0c-8704-376fe6159c54" />


#### Steps to Test

**review**:
@Arelle/arelle
@paulwarren-wk
