### PR TITLE
Fix runtime config feature merge and allow skinning doc title

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,9 @@ parameters, as defined above.
   - `stylesheetUrl` - a URL to additional CSS definitions.
   - `faviconUrl` - a URL to an icon file to be used as the favicon for the viewer.
   - `footerLogoHtml` - a fragment of HTML that will be included in place of the standard footer logo.
+  - `titlePrefix` - a string used in place of `Inline Viewer` in the page title,
+      giving `<titlePrefix> - <report title>`, or just `<titlePrefix>` if the
+      report has no title.
 
 - `taxonomyNames` - a JSON object where:
 

--- a/docs/sample-config.json
+++ b/docs/sample-config.json
@@ -1,6 +1,7 @@
 {
     "skin": {
         "stylesheetUrl": "./myskin.css",
+        "titlePrefix": "Demo App",
         "footerLogoHtml": "<b>Footer override</b>"
     },
     "features": {

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -310,10 +310,7 @@ export class iXBRLViewer {
                 return obj;
             }, {});
         }
-        if (runtimeConfigFeatures !== undefined) {
-            features = {...runtimeConfigFeatures, features};
-        }
-        return features;
+        return {...runtimeConfigFeatures, ...features};
     }
 
     load() {

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -187,7 +187,7 @@ export class iXBRLViewer {
                 .appendTo('head');
         }
         if (this.runtimeConfig.skin?.faviconUrl !== undefined) {
-            $('<link id="ixv-favicon" type="image/x-icon" rel="shortcut icon" />')
+            $('<link id="ixv-favicon" rel="icon" />')
                 .attr('href', this.resolveRelativeUrl(this.runtimeConfig.skin.faviconUrl))
                 .appendTo('head');
         }

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -220,13 +220,9 @@ export class iXBRLViewer {
         doc.write("<!DOCTYPE html><html><head><title></title></head><body></body></html>");
         doc.close();
 
-        let docTitle = $('title').text();
-        if (docTitle !== "") {
-            docTitle = `Inline Viewer - ${docTitle}`;
-        }
-        else {
-            docTitle = "Inline Viewer";
-        }
+        const titlePrefix = this.runtimeConfig.skin?.titlePrefix ?? "Inline Viewer";
+        const reportTitle = $('title').text();
+        const docTitle = reportTitle !== "" ? `${titlePrefix} - ${reportTitle}` : titlePrefix;
 
 
         $('head')

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.js
@@ -297,6 +297,25 @@ export class iXBRLViewer {
         });
     }
 
+    _mergeFeatures(generationFeatures, runtimeConfigFeatures) {
+        let features = generationFeatures;
+        if (!features) {
+            features = {};
+        }
+        // `features` was previously an array of flag values
+        // Support this for backwards compatability
+        else if (Array.isArray(features)) {
+            features = features.reduce((obj, val) => {
+                obj[val] = true;
+                return obj;
+            }, {});
+        }
+        if (runtimeConfigFeatures !== undefined) {
+            features = {...runtimeConfigFeatures, features};
+        }
+        return features;
+    }
+
     load() {
         const iv = this;
         const inspector = this.inspector;
@@ -320,21 +339,7 @@ export class iXBRLViewer {
             // We need to parse JSON first so that we can determine feature enablement before loading begins.
             const taxonomyData = iv._getTaxonomyData();
             const parsedTaxonomyData = taxonomyData && JSON.parse(taxonomyData);
-            let features = parsedTaxonomyData?.features;
-            if (!features) {
-                features = {};
-            }
-            // `features` was previously an array of flag values
-            // Support this for backwards compatability
-            else if (Array.isArray(features)) {
-                features = features.reduce((obj, val) => {
-                    obj[val] = true;
-                    return obj;
-                }, {});
-            }
-            if (this.runtimeConfig.features !== undefined) {
-                features = {...this.runtimeConfig.features, features};
-            }
+            const features = iv._mergeFeatures(parsedTaxonomyData?.features, this.runtimeConfig.features);
             iv.setFeatures(features, window.location.search);
 
             const reportSet = new ReportSet(parsedTaxonomyData);

--- a/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/ixbrlviewer.test.js
@@ -112,6 +112,42 @@ describe("Feature enablement", () => {
     });
 });
 
+describe("Feature merging", () => {
+    var viewer = null;
+    beforeAll(() => {
+        viewer = new iXBRLViewer({})
+    });
+
+    test("Config features and generation features are both retained", () => {
+        expect(viewer._mergeFeatures({'a': true}, {'b': true}))
+            .toEqual({'a': true, 'b': true});
+    });
+
+    test("Generation time value wins on collision", () => {
+        expect(viewer._mergeFeatures({'a': '1'}, {'a': '2'}))
+            .toEqual({'a': '1'});
+    });
+
+    test("Legacy array form of generation features is normalised", () => {
+        expect(viewer._mergeFeatures(['a', 'b'], undefined))
+            .toEqual({'a': true, 'b': true});
+    });
+
+    test("Legacy array form merges with config features", () => {
+        expect(viewer._mergeFeatures(['a'], {'b': true}))
+            .toEqual({'a': true, 'b': true});
+    });
+
+    test("No config features leaves generation features untouched", () => {
+        expect(viewer._mergeFeatures({'a': true}, undefined))
+            .toEqual({'a': true});
+    });
+
+    test("No features at either level gives an empty set", () => {
+        expect(viewer._mergeFeatures(undefined, undefined)).toEqual({});
+    });
+});
+
 describe("Review mode enablement", () => {
     var viewer = null;
     beforeAll(() => {


### PR DESCRIPTION
#### Reason for change

Runtime config `features` were merged incorrectly, producing a nested `features` key rather than merged flags. Deployers also had no way to change the `Inline Viewer` page title prefix, and the skinned favicon link hardcoded `type="image/x-icon"`, which is wrong for non-ICO files.

#### Description of change

- Extract feature merging into tested `_mergeFeatures` and fix the spread so generation features override runtime config features.
- Add `skin.titlePrefix` to allow replacing `Inline Viewer` in the page title.
- Drop the hardcoded `type` and use `rel="icon"` on the skinned favicon link, letting the browser sniff the format.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
@paulwarren-wk
