### PR TITLE
Wrap long concept and member names in inspector

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/inspector.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.js
@@ -48,6 +48,7 @@ export class Inspector {
         this._curInspectorMode = undefined;
         this._prevInspectorMode = undefined;
         this._searchReady = false;
+        this._factListScrollTop = undefined;
     }
 
     i18nInit() {
@@ -351,7 +352,7 @@ export class Inspector {
         else {
             this.inspectorMode("fact-mode");
             if (this.outline.hasOutline()) {
-                $("#inspector").addClass("show-facts-by-group");
+                this._showFactList();
             }
         }
     }
@@ -622,12 +623,34 @@ export class Inspector {
         $("#ixv").removeClass("show-filters");
         $("#ixv").removeClass(allModes.filter(m => m !== mode)).addClass(mode);
         if (focusInspector === true) {
-            $("#inspector").removeClass("show-facts-by-group");
+            this._showFactDetails();
         }
         else if ((focusInspector === false || this._curInspectorMode === "fact-mode" && mode === "fact-mode") && this.outline.hasOutline()) {
-            $("#inspector").addClass("show-facts-by-group");
+            this._showFactList();
         }
         this._curInspectorMode = mode;
+    }
+
+    _factInspectorBody() {
+        return $("#inspector .fact-inspector > .inspector-body");
+    }
+
+    _showFactDetails() {
+        const body = this._factInspectorBody();
+        if ($("#inspector").hasClass("show-facts-by-group")) {
+            this._factListScrollTop = body.scrollTop();
+        }
+        $("#inspector").removeClass("show-facts-by-group");
+        body.scrollTop(0);
+    }
+
+    _showFactList() {
+        const wasShowingList = $("#inspector").hasClass("show-facts-by-group");
+        $("#inspector").addClass("show-facts-by-group");
+        if (!wasShowingList && this._factListScrollTop !== undefined) {
+            this._factInspectorBody().scrollTop(this._factListScrollTop);
+            this._factListScrollTop = undefined;
+        }
     }
 
     toggleSettingsMode() {
@@ -1845,7 +1868,7 @@ export class Inspector {
             $('#inspector').removeClass('footnote-mode');
             $('#inspector').addClass('no-fact-selected');
             if (this.outline.hasOutline()) {
-                $('#inspector').addClass('show-facts-by-group');
+                this._showFactList();
             }
         } 
         else { 

--- a/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/inspector.test.js
@@ -933,6 +933,104 @@ describe("Facts by group", () => {
     });
 });
 
+describe("inspectorMode fact details scroll", () => {
+    beforeEach(() => {
+        $("#ixv, #inspector").remove();
+        $(document.body).append(`
+            <div id="ixv">
+              <div id="inspector" class="show-facts-by-group">
+                <div class="inspector-container fact-inspector">
+                  <div class="inspector-body"></div>
+                </div>
+              </div>
+            </div>
+        `);
+    });
+
+    afterEach(() => {
+        $("#ixv, #inspector").remove();
+    });
+
+    test("opening fact details resets the inspector body to the top", () => {
+        const insp = new TestInspector();
+        expect(insp._factListScrollTop).toBeUndefined();
+        const body = $("#inspector .fact-inspector > .inspector-body");
+        body.scrollTop(500);
+        expect(body.scrollTop()).toBe(500);
+
+        insp.inspectorMode("fact-mode", true);
+
+        expect(body.scrollTop()).toBe(0);
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(false);
+    });
+
+    test("returning to the fact list does not reset inspector body scroll", () => {
+        const insp = new TestInspector();
+        insp.outline = { hasOutline: () => true };
+        const body = $("#inspector .fact-inspector > .inspector-body");
+        body.scrollTop(500);
+
+        insp.inspectorMode("fact-mode", false);
+
+        expect(body.scrollTop()).toBe(500);
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(true);
+    });
+
+    test("returning to the fact list restores the scroll saved when opening details", () => {
+        const insp = new TestInspector();
+        insp.outline = { hasOutline: () => true };
+        insp._curInspectorMode = "fact-mode";
+        const body = $("#inspector .fact-inspector > .inspector-body");
+        body.scrollTop(500);
+
+        insp.inspectorMode("fact-mode", true);
+        expect(body.scrollTop()).toBe(0);
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(false);
+
+        insp.inspectorMode("fact-mode");
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(true);
+        expect(body.scrollTop()).toBe(500);
+        expect(insp._factListScrollTop).toBeUndefined();
+    });
+
+    test("search then XBRL facts returns to details at the top; a second XBRL facts click restores the list scroll", () => {
+        const insp = new TestInspector();
+        insp.outline = { hasOutline: () => true };
+        insp._curInspectorMode = "fact-mode";
+        const body = $("#inspector .fact-inspector > .inspector-body");
+        body.scrollTop(500);
+
+        insp.inspectorMode("fact-mode", true);
+        insp.inspectorMode("search-mode");
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(false);
+        expect(body.scrollTop()).toBe(0);
+
+        insp.inspectorMode("fact-mode");
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(false);
+        expect(body.scrollTop()).toBe(0);
+
+        insp.inspectorMode("fact-mode");
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(true);
+        expect(body.scrollTop()).toBe(500);
+    });
+
+    test("clicking XBRL facts while already on the list does not restore a stale list scroll", () => {
+        const insp = new TestInspector();
+        insp.outline = { hasOutline: () => true };
+        insp._curInspectorMode = "fact-mode";
+        const body = $("#inspector .fact-inspector > .inspector-body");
+        body.scrollTop(500);
+
+        insp.inspectorMode("fact-mode", true);
+        insp.inspectorMode("fact-mode");
+        body.scrollTop(800);
+        insp.inspectorMode("fact-mode");
+
+        expect($("#inspector").hasClass("show-facts-by-group")).toBe(true);
+        expect(body.scrollTop()).toBe(800);
+    });
+});
+
 describe("Collapsible sections", () => {
     function setUpSections() {
         const insp = new TestInspector();

--- a/iXBRLViewerPlugin/viewer/src/less/block-list.less
+++ b/iXBRLViewerPlugin/viewer/src/less/block-list.less
@@ -9,7 +9,10 @@
   border-radius: 0.8rem;
   text-align: left;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   display: block;
+  overflow-wrap: anywhere;
 
   & > * {
     margin: 0.8rem 0;

--- a/iXBRLViewerPlugin/viewer/src/less/inspector.less
+++ b/iXBRLViewerPlugin/viewer/src/less/inspector.less
@@ -797,7 +797,9 @@ a {
 
         h2.concept-name-title {
           flex: 1 1 55%;
+          min-width: 0;
           padding: 0;
+          overflow-wrap: anywhere;
         }
 
         .tags {
@@ -905,6 +907,7 @@ a {
     .dimension {
       position: relative;
       margin: 1.5rem 0 1.5rem 1rem;
+      overflow-wrap: anywhere;
 
       &::before {
         .icon-dimension();
@@ -920,6 +923,7 @@ a {
     .dimension-value {
       position: relative;
       margin: 1.5rem 0 1.5rem 3.5rem;
+      overflow-wrap: anywhere;
 
       &::before {
         .icon-dimension-member();
@@ -1462,11 +1466,15 @@ a {
 
     .title {
       .link-style();
+
+      max-width: 100%;
+      overflow-wrap: anywhere;
     }
 
     .dimension {
       color: var(--colour-text);
       margin: 0.6rem 0;
+      overflow-wrap: anywhere;
     }
 
     .datatype {


### PR DESCRIPTION
#### Reason for change

Unbreakable camelCase labels were expanding fact list rows and the details pane, which made the inspector scroll horizontally.

Also fixes an issue where the scroll position was shared between the fact group and fact details panels, so scrolling to the bottom of the facts list and clicking into a fact caused the user to be sent to the bottom of the fact details pane.

<img width="400" height="568" alt="overflow" src="https://github.com/user-attachments/assets/7b5cec19-aad0-403e-a6ae-f4c27f3836c3" />

#### Description of change

* Wrap long labels/names.
* Set inspector to top when open fact details.
* Restore fact group scroll position when navigating back from details.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
@paulwarren-wk
