### PR TITLE
Improve highlight all tags performance

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -785,25 +785,47 @@ export class Viewer {
     }
 
     _applyHighlightToFactWrappers(groups) {
-        $(".ixbrl-element", this._contents)
-            .addClass("ixbrl-highlight")
-            .each((_i, element) => {
-                // Find the first ixn for this element that isn't a footnote.
-                // Choosing the first means that we're arbitrarily choosing a
-                // highlight color for an element that is double tagged in a
-                // table cell.
-                const ixn = $(element).data('ivids').map(id => this._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
-                if (ixn !== undefined ) {
-                    const item = this._reportSet.getItemById(ixn.id);
-                    if (item !== undefined) {
-                        const color = groups.get(item.conceptQName().prefix);
-                        if (color !== undefined) {
-                            const elements = this.primaryElementsForItemIds(ixn.chainIXIds());
-                            elements.addClass(`ixbrl-highlight-${color}`);
-                        }
-                    }
+        const seenIds = new Set();
+        const coloredElements = new Set();
+        for (const [vuid, ixn] of Object.entries(this._ixNodeMap)) {
+            if (this.continuationOfMap?.[vuid] !== undefined) {
+                continue;
+            }
+            const color = this._namespaceHighlightColor(ixn, groups);
+            for (const id of ixn.chainIXIds()) {
+                if (seenIds.has(id)) {
+                    continue;
                 }
-        });
+                seenIds.add(id);
+                const chainNode = this._ixNodeMap[id];
+                if (chainNode !== undefined) {
+                    this._highlightPrimaryWrappers(chainNode, color, coloredElements);
+                }
+            }
+        }
+    }
+
+    _namespaceHighlightColor(ixn, groups) {
+        if (ixn.footnote) {
+            return undefined;
+        }
+        const item = this._reportSet.getItemById(ixn.id);
+        if (item === undefined) {
+            return undefined;
+        }
+        return groups.get(item.conceptQName().prefix);
+    }
+
+    _highlightPrimaryWrappers(ixn, color, coloredElements) {
+        const primaryElements = this.primaryElementsForItemIds([ixn.id]).get();
+        for (const element of primaryElements) {
+            const classes = ["ixbrl-highlight"];
+            if (color !== undefined && !coloredElements.has(element)) {
+                classes.push(`ixbrl-highlight-${color}`);
+                coloredElements.add(element);
+            }
+            element.classList.add(...classes);
+        }
     }
 
     zoom(pct) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -33,6 +33,7 @@ export class Viewer {
         this._ixNodeMap = {};
         this.docOrderItemIndex = new DocOrderIndex();
         this._currentDocumentIndex = 0;
+        this._highlightAllPrepared = false;
     }
 
     _checkContinuationCount() {
@@ -767,14 +768,18 @@ export class Viewer {
     }
 
     highlightAllTags(on, namespaceGroups) {
-        if (on) {
+        if (on && !this._highlightAllPrepared) {
             const groups = new Map(namespaceGroups.map((ns, i) => [ns, i % HIGHLIGHT_COLORS]));
             this._applyHighlightToFactWrappers(groups);
+            this._highlightAllPrepared = true;
         }
-        else {
-            $(".ixbrl-element", this._contents).removeClass(
-                (i, className) => (className.match (/(^|\s)ixbrl-highlight\S*/g) || []).join(' ')
-            );
+        this._toggleHighlightAll(on);
+    }
+
+    _toggleHighlightAll(on) {
+        for (const iframe of this._iframes.get()) {
+            const body = iframe.contentDocument?.body;
+            body?.classList.toggle("ixbrl-highlight-all", !!on);
         }
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -767,11 +767,8 @@ export class Viewer {
     }
 
     highlightAllTags(on, namespaceGroups) {
-        const groups = {};
-        $.each(namespaceGroups, function (i, ns) {
-            groups[ns] = i % HIGHLIGHT_COLORS;
-        });
         if (on) {
+            const groups = new Map(namespaceGroups.map((ns, i) => [ns, i % HIGHLIGHT_COLORS]));
             this._applyHighlightToFactWrappers(groups);
         }
         else {
@@ -782,23 +779,21 @@ export class Viewer {
     }
 
     _applyHighlightToFactWrappers(groups) {
-        const reportSet = this._reportSet;
-        const viewer = this;
         $(".ixbrl-element", this._contents)
             .addClass("ixbrl-highlight")
-            .each(function () {
+            .each((_i, element) => {
                 // Find the first ixn for this element that isn't a footnote.
                 // Choosing the first means that we're arbitrarily choosing a
                 // highlight color for an element that is double tagged in a
                 // table cell.
-                const ixn = $(this).data('ivids').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
+                const ixn = $(element).data('ivids').map(id => this._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
                 if (ixn !== undefined ) {
-                    const item = reportSet.getItemById(ixn.id);
+                    const item = this._reportSet.getItemById(ixn.id);
                     if (item !== undefined) {
-                        const elements = viewer.primaryElementsForItemIds(ixn.chainIXIds());
-                        const i = groups[item.conceptQName().prefix];
-                        if (i !== undefined) {
-                            elements.addClass("ixbrl-highlight-" + i);
+                        const color = groups.get(item.conceptQName().prefix);
+                        if (color !== undefined) {
+                            const elements = this.primaryElementsForItemIds(ixn.chainIXIds());
+                            elements.addClass(`ixbrl-highlight-${color}`);
                         }
                     }
                 }

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -771,34 +771,38 @@ export class Viewer {
         $.each(namespaceGroups, function (i, ns) {
             groups[ns] = i % HIGHLIGHT_COLORS;
         });
-        const reportSet = this._reportSet;
-        const viewer = this;
         if (on) {
-            $(".ixbrl-element", this._contents)
-                .addClass("ixbrl-highlight")
-                .each(function () {
-                    // Find the first ixn for this element that isn't a footnote.
-                    // Choosing the first means that we're arbitrarily choosing a
-                    // highlight color for an element that is double tagged in a
-                    // table cell.
-                    const ixn = $(this).data('ivids').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
-                    if (ixn !== undefined ) {
-                        const item = reportSet.getItemById(ixn.id);
-                        if (item !== undefined) {
-                            const elements = viewer.primaryElementsForItemIds(ixn.chainIXIds());
-                            const i = groups[item.conceptQName().prefix];
-                            if (i !== undefined) {
-                                elements.addClass("ixbrl-highlight-" + i);
-                            }
-                        }
-                    }
-            });
+            this._applyHighlightToFactWrappers(groups);
         }
         else {
             $(".ixbrl-element", this._contents).removeClass(
                 (i, className) => (className.match (/(^|\s)ixbrl-highlight\S*/g) || []).join(' ')
             );
         }
+    }
+
+    _applyHighlightToFactWrappers(groups) {
+        const reportSet = this._reportSet;
+        const viewer = this;
+        $(".ixbrl-element", this._contents)
+            .addClass("ixbrl-highlight")
+            .each(function () {
+                // Find the first ixn for this element that isn't a footnote.
+                // Choosing the first means that we're arbitrarily choosing a
+                // highlight color for an element that is double tagged in a
+                // table cell.
+                const ixn = $(this).data('ivids').map(id => viewer._ixNodeMap[id]).filter(ixn => !ixn.footnote)[0];
+                if (ixn !== undefined ) {
+                    const item = reportSet.getItemById(ixn.id);
+                    if (item !== undefined) {
+                        const elements = viewer.primaryElementsForItemIds(ixn.chainIXIds());
+                        const i = groups[item.conceptQName().prefix];
+                        if (i !== undefined) {
+                            elements.addClass("ixbrl-highlight-" + i);
+                        }
+                    }
+                }
+        });
     }
 
     zoom(pct) {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -768,7 +768,8 @@ export class Viewer {
     }
 
     highlightAllTags(on, namespaceGroups) {
-        if (on && !this._highlightAllPrepared) {
+        const reviewMode = this._iv?.isReviewModeEnabled?.() === true;
+        if (on && !this._highlightAllPrepared && !reviewMode) {
             const groups = new Map(namespaceGroups.map((ns, i) => [ns, i % HIGHLIGHT_COLORS]));
             this._applyHighlightToFactWrappers(groups);
             this._highlightAllPrepared = true;

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -71,19 +71,50 @@ describe("highlightAllTags", () => {
         document.body.innerHTML = "";
     });
 
-    test.each([false, true])("preserves highlight behavior in %s mode", (reviewMode) => {
-        const { viewer, wrapper } = makeHighlightViewer(reviewMode);
+    test.each([false, true])("toggles report-body highlighting in %s mode", (reviewMode) => {
+        const { viewer, wrapper, doc } = makeHighlightViewer(reviewMode);
         const groups = viewer._reportSet.namespaceGroups();
 
         viewer.highlightAllTags(true, groups);
 
+        expect(doc.body.classList.contains("ixbrl-highlight-all")).toBe(true);
         expect(wrapper.classList.contains("ixbrl-highlight")).toBe(true);
         expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(true);
 
         viewer.highlightAllTags(false, groups);
 
-        expect(wrapper.classList.contains("ixbrl-highlight")).toBe(false);
-        expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(false);
+        expect(doc.body.classList.contains("ixbrl-highlight-all")).toBe(false);
+        expect(wrapper.classList.contains("ixbrl-highlight")).toBe(true);
+        expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(true);
+    });
+
+    test.each([false, true])("prepares node classes only once in %s mode", (reviewMode) => {
+        const { viewer } = makeHighlightViewer(reviewMode);
+        const applyHighlightToFactWrappers = jest.spyOn(viewer, "_applyHighlightToFactWrappers");
+        const groups = viewer._reportSet.namespaceGroups();
+
+        viewer.highlightAllTags(true, groups);
+        viewer.highlightAllTags(false, groups);
+        viewer.highlightAllTags(true, groups);
+
+        expect(applyHighlightToFactWrappers).toHaveBeenCalledTimes(1);
+    });
+
+    test("toggles highlighting on every report iframe body", () => {
+        const { viewer, doc } = makeHighlightViewer(false);
+        const secondIframe = document.createElement("iframe");
+        document.body.appendChild(secondIframe);
+        viewer._iframes = $([viewer._iframes.get(0), secondIframe]);
+
+        viewer.highlightAllTags(true, viewer._reportSet.namespaceGroups());
+
+        expect(doc.body.classList.contains("ixbrl-highlight-all")).toBe(true);
+        expect(secondIframe.contentDocument.body.classList.contains("ixbrl-highlight-all")).toBe(true);
+
+        viewer.highlightAllTags(false, viewer._reportSet.namespaceGroups());
+
+        expect(doc.body.classList.contains("ixbrl-highlight-all")).toBe(false);
+        expect(secondIframe.contentDocument.body.classList.contains("ixbrl-highlight-all")).toBe(false);
     });
 
     test("keeps namespace colors on primary fact wrappers", () => {

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -1,0 +1,191 @@
+import $ from "jquery";
+import { IXNode } from "./ixnode.js";
+import { ReportSet } from "./reportset.js";
+import { Viewer } from "./viewer.js";
+import { NAMESPACE_ISO4217, viewerUniqueId } from "./util.js";
+
+function highlightReportData(facts) {
+    return {
+        prefixes: {
+            eg: "http://www.example.com",
+            iso4217: NAMESPACE_ISO4217,
+        },
+        concepts: {
+            "eg:Concept1": { labels: { std: { en: "A" } } },
+            "other:Concept2": { labels: { std: { en: "B" } } },
+        },
+        facts,
+        languages: {},
+        roles: {},
+        roleDefs: {},
+        rels: {},
+    };
+}
+
+function highlightFact(concept) {
+    return {
+        v: 1,
+        a: {
+            c: concept,
+            u: "iso4217:USD",
+            p: "2017-01-01/2018-01-01",
+        },
+    };
+}
+
+function appendHighlightWrapper(doc, className = "ixbrl-element") {
+    const wrapper = doc.createElement("span");
+    wrapper.className = className;
+    doc.body.appendChild(wrapper);
+    return wrapper;
+}
+
+function makeHighlightViewer(reviewMode = false, facts, buildNodes) {
+    const iframe = document.createElement("iframe");
+    document.body.appendChild(iframe);
+    const doc = iframe.contentDocument;
+    const factId = viewerUniqueId(0, "f1");
+    const wrapper = buildNodes === undefined ? appendHighlightWrapper(doc) : undefined;
+    if (wrapper !== undefined) {
+        $(wrapper).data("ivids", [factId]);
+    }
+    const ixNodeMap = buildNodes === undefined
+        ? { [factId]: new IXNode(factId, $(wrapper), 0) }
+        : buildNodes(doc);
+    const reportSet = new ReportSet(highlightReportData(facts ?? {
+        f1: highlightFact("eg:Concept1"),
+    }));
+    reportSet.setIXNodeMap(ixNodeMap);
+    const viewer = new Viewer(
+        { options: {}, isReviewModeEnabled: () => reviewMode },
+        $(iframe),
+        reportSet
+    );
+    viewer._ixNodeMap = ixNodeMap;
+    viewer.continuationOfMap = {};
+    return { viewer, wrapper, doc };
+}
+
+describe("highlightAllTags", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    test.each([false, true])("preserves highlight behavior in %s mode", (reviewMode) => {
+        const { viewer, wrapper } = makeHighlightViewer(reviewMode);
+        const groups = viewer._reportSet.namespaceGroups();
+
+        viewer.highlightAllTags(true, groups);
+
+        expect(wrapper.classList.contains("ixbrl-highlight")).toBe(true);
+        expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(true);
+
+        viewer.highlightAllTags(false, groups);
+
+        expect(wrapper.classList.contains("ixbrl-highlight")).toBe(false);
+        expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(false);
+    });
+
+    test("keeps namespace colors on primary fact wrappers", () => {
+        const f1 = viewerUniqueId(0, "f1");
+        const f2 = viewerUniqueId(0, "f2");
+        const { viewer, doc } = makeHighlightViewer(
+            false,
+            {
+                f1: highlightFact("eg:Concept1"),
+                f2: highlightFact("other:Concept2"),
+            },
+            (reportDoc) => {
+                const first = appendHighlightWrapper(reportDoc);
+                const second = appendHighlightWrapper(reportDoc);
+                $(first).data("ivids", [f1]);
+                $(second).data("ivids", [f2]);
+                return {
+                    [f1]: new IXNode(f1, $(first), 0),
+                    [f2]: new IXNode(f2, $(second), 0),
+                };
+            }
+        );
+
+        viewer.highlightAllTags(true, viewer._reportSet.namespaceGroups());
+
+        const elements = [...doc.querySelectorAll(".ixbrl-element")];
+        expect(elements[0].classList.contains("ixbrl-highlight-0")).toBe(true);
+        expect(elements[1].classList.contains("ixbrl-highlight-1")).toBe(true);
+    });
+
+    test("colors continuation wrappers with their head fact", () => {
+        const f1 = viewerUniqueId(0, "f1");
+        const c1 = viewerUniqueId(0, "c1");
+        const { viewer, doc } = makeHighlightViewer(
+            false,
+            { f1: highlightFact("eg:Concept1") },
+            (reportDoc) => {
+                const headWrapper = appendHighlightWrapper(reportDoc);
+                const continuationWrapper = appendHighlightWrapper(reportDoc);
+                $(headWrapper).data("ivids", [f1]);
+                $(continuationWrapper).data("ivids", [f1]);
+                const head = new IXNode(f1, $(headWrapper), 0);
+                const continuation = new IXNode(c1, $(continuationWrapper), 0);
+                head.continuations = [continuation];
+                return { [f1]: head, [c1]: continuation };
+            }
+        );
+        viewer.continuationOfMap = { [c1]: f1 };
+
+        viewer.highlightAllTags(true, viewer._reportSet.namespaceGroups());
+
+        const elements = [...doc.querySelectorAll(".ixbrl-element")];
+        expect(elements[0].classList.contains("ixbrl-highlight-0")).toBe(true);
+        expect(elements[1].classList.contains("ixbrl-highlight-0")).toBe(true);
+    });
+
+    test("does not color sub-elements as primary wrappers", () => {
+        const f1 = viewerUniqueId(0, "f1");
+        let subElement;
+        const { viewer, doc } = makeHighlightViewer(
+            false,
+            { f1: highlightFact("eg:Concept1") },
+            (reportDoc) => {
+                const primary = appendHighlightWrapper(reportDoc);
+                subElement = appendHighlightWrapper(reportDoc, "ixbrl-sub-element");
+                $(primary).data("ivids", [f1]);
+                return { [f1]: new IXNode(f1, $(primary).add(subElement), 0) };
+            }
+        );
+
+        viewer.highlightAllTags(true, viewer._reportSet.namespaceGroups());
+
+        expect(doc.querySelector(".ixbrl-element").classList.contains("ixbrl-highlight-0")).toBe(true);
+        expect(doc.querySelector(".ixbrl-element").classList.contains("ixbrl-highlight")).toBe(true);
+        expect(subElement.classList.contains("ixbrl-highlight")).toBe(false);
+        expect(subElement.classList.contains("ixbrl-highlight-0")).toBe(false);
+    });
+
+    test("keeps the first namespace color on a double-tagged wrapper", () => {
+        const f1 = viewerUniqueId(0, "f1");
+        const f2 = viewerUniqueId(0, "f2");
+        const { viewer, doc } = makeHighlightViewer(
+            false,
+            {
+                f1: highlightFact("eg:Concept1"),
+                f2: highlightFact("other:Concept2"),
+            },
+            (reportDoc) => {
+                const wrapper = appendHighlightWrapper(reportDoc);
+                $(wrapper).data("ivids", [f1, f2]);
+                const wrappedNode = $(wrapper);
+                return {
+                    [f1]: new IXNode(f1, wrappedNode, 0),
+                    [f2]: new IXNode(f2, wrappedNode, 0),
+                };
+            }
+        );
+
+        viewer.highlightAllTags(true, viewer._reportSet.namespaceGroups());
+
+        const element = doc.querySelector(".ixbrl-element");
+        expect(element.classList.contains("ixbrl-highlight-0")).toBe(true);
+        expect(element.classList.contains("ixbrl-highlight-1")).toBe(false);
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -158,8 +158,6 @@ describe("highlightAllTags", () => {
             (reportDoc) => {
                 const first = appendHighlightWrapper(reportDoc);
                 const second = appendHighlightWrapper(reportDoc);
-                $(first).data("ivids", [f1]);
-                $(second).data("ivids", [f2]);
                 return {
                     [f1]: new IXNode(f1, $(first), 0),
                     [f2]: new IXNode(f2, $(second), 0),
@@ -183,8 +181,6 @@ describe("highlightAllTags", () => {
             (reportDoc) => {
                 const headWrapper = appendHighlightWrapper(reportDoc);
                 const continuationWrapper = appendHighlightWrapper(reportDoc);
-                $(headWrapper).data("ivids", [f1]);
-                $(continuationWrapper).data("ivids", [f1]);
                 const head = new IXNode(f1, $(headWrapper), 0);
                 const continuation = new IXNode(c1, $(continuationWrapper), 0);
                 head.continuations = [continuation];
@@ -200,6 +196,33 @@ describe("highlightAllTags", () => {
         expect(elements[1].classList.contains("ixbrl-highlight-0")).toBe(true);
     });
 
+    test("prepares each mapped chain node once", () => {
+        const f1 = viewerUniqueId(0, "f1");
+        const f2 = viewerUniqueId(0, "f2");
+        const c1 = viewerUniqueId(0, "c1");
+        const { viewer } = makeHighlightViewer(
+            false,
+            {
+                f1: highlightFact("eg:Concept1"),
+                f2: highlightFact("other:Concept2"),
+            },
+            (reportDoc) => {
+                const first = new IXNode(f1, $(appendHighlightWrapper(reportDoc)), 0);
+                const second = new IXNode(f2, $(appendHighlightWrapper(reportDoc)), 0);
+                const continuation = new IXNode(c1, $(appendHighlightWrapper(reportDoc)), 0);
+                first.continuations = [continuation];
+                second.continuations = [continuation];
+                return { [f1]: first, [f2]: second, [c1]: continuation };
+            }
+        );
+        viewer.continuationOfMap = { [c1]: f1 };
+        const highlightPrimaryWrappers = jest.spyOn(viewer, "_highlightPrimaryWrappers");
+
+        viewer.highlightAllTags(true, viewer._reportSet.namespaceGroups());
+
+        expect(highlightPrimaryWrappers).toHaveBeenCalledTimes(3);
+    });
+
     test("does not color sub-elements as primary wrappers", () => {
         const f1 = viewerUniqueId(0, "f1");
         let subElement;
@@ -209,7 +232,6 @@ describe("highlightAllTags", () => {
             (reportDoc) => {
                 const primary = appendHighlightWrapper(reportDoc);
                 subElement = appendHighlightWrapper(reportDoc, "ixbrl-sub-element");
-                $(primary).data("ivids", [f1]);
                 return { [f1]: new IXNode(f1, $(primary).add(subElement), 0) };
             }
         );
@@ -233,7 +255,6 @@ describe("highlightAllTags", () => {
             },
             (reportDoc) => {
                 const wrapper = appendHighlightWrapper(reportDoc);
-                $(wrapper).data("ivids", [f1, f2]);
                 const wrappedNode = $(wrapper);
                 return {
                     [f1]: new IXNode(f1, wrappedNode, 0),

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -71,8 +71,8 @@ describe("highlightAllTags", () => {
         document.body.innerHTML = "";
     });
 
-    test.each([false, true])("toggles report-body highlighting in %s mode", (reviewMode) => {
-        const { viewer, wrapper, doc } = makeHighlightViewer(reviewMode);
+    test("non-review mode toggles report-body highlighting", () => {
+        const { viewer, wrapper, doc } = makeHighlightViewer(false);
         const groups = viewer._reportSet.namespaceGroups();
 
         viewer.highlightAllTags(true, groups);
@@ -88,8 +88,25 @@ describe("highlightAllTags", () => {
         expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(true);
     });
 
-    test.each([false, true])("prepares node classes only once in %s mode", (reviewMode) => {
-        const { viewer } = makeHighlightViewer(reviewMode);
+    test("review mode toggles report body highlighting without node classes", () => {
+        const { viewer, wrapper, doc } = makeHighlightViewer(true);
+        const applyHighlightToFactWrappers = jest.spyOn(viewer, "_applyHighlightToFactWrappers");
+        const groups = viewer._reportSet.namespaceGroups();
+
+        viewer.highlightAllTags(true, groups);
+
+        expect(doc.body.classList.contains("ixbrl-highlight-all")).toBe(true);
+        expect(wrapper.classList.contains("ixbrl-highlight")).toBe(false);
+        expect(wrapper.classList.contains("ixbrl-highlight-0")).toBe(false);
+        expect(applyHighlightToFactWrappers).not.toHaveBeenCalled();
+
+        viewer.highlightAllTags(false, groups);
+
+        expect(doc.body.classList.contains("ixbrl-highlight-all")).toBe(false);
+    });
+
+    test("non-review mode prepares node classes only once", () => {
+        const { viewer } = makeHighlightViewer(false);
         const applyHighlightToFactWrappers = jest.spyOn(viewer, "_applyHighlightToFactWrappers");
         const groups = viewer._reportSet.namespaceGroups();
 
@@ -98,6 +115,18 @@ describe("highlightAllTags", () => {
         viewer.highlightAllTags(true, groups);
 
         expect(applyHighlightToFactWrappers).toHaveBeenCalledTimes(1);
+    });
+
+    test("review mode never prepares node classes", () => {
+        const { viewer } = makeHighlightViewer(true);
+        const applyHighlightToFactWrappers = jest.spyOn(viewer, "_applyHighlightToFactWrappers");
+        const groups = viewer._reportSet.namespaceGroups();
+
+        viewer.highlightAllTags(true, groups);
+        viewer.highlightAllTags(false, groups);
+        viewer.highlightAllTags(true, groups);
+
+        expect(applyHighlightToFactWrappers).not.toHaveBeenCalled();
     });
 
     test("toggles highlighting on every report iframe body", () => {

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -23,7 +23,7 @@
 // To ensure highlighting takes place, !important is used to override inline styles.
 // For example: overrides highlighting applied inline to alternate table rows.
 
-.ixbrl-highlight {
+body.ixbrl-highlight-all .ixbrl-highlight {
   &:not(.ixbrl-no-highlight),
   & .ixbrl-sub-element:not(.ixbrl-no-highlight) {
       background-color: var(--colour-highlight-default) !important; // Override inline styles
@@ -63,7 +63,7 @@
   background-color: var(--colour-highlight-2);
 }
 
-.review .ixbrl-highlight {
+.review.ixbrl-highlight-all .ixbrl-highlight {
   &:not(.ixbrl-no-highlight).ixbrl-highlight-1, 
   &:not(.ixbrl-no-highlight).ixbrl-highlight-2, 
   &:not(.ixbrl-no-highlight).ixbrl-highlight-3, 

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -63,17 +63,9 @@ body.ixbrl-highlight-all .ixbrl-highlight {
   background-color: var(--colour-highlight-2);
 }
 
-.review.ixbrl-highlight-all .ixbrl-highlight {
-  &:not(.ixbrl-no-highlight).ixbrl-highlight-1, 
-  &:not(.ixbrl-no-highlight).ixbrl-highlight-2, 
-  &:not(.ixbrl-no-highlight).ixbrl-highlight-3, 
-  &:not(.ixbrl-no-highlight).ixbrl-highlight-4, 
-  &:not(.ixbrl-no-highlight).ixbrl-highlight-5, 
-  &.ixbrl-highlight-1 .ixbrl-sub-element:not(.ixbrl-no-highlight),
-  &.ixbrl-highlight-2 .ixbrl-sub-element:not(.ixbrl-no-highlight),
-  &.ixbrl-highlight-3 .ixbrl-sub-element:not(.ixbrl-no-highlight),
-  &.ixbrl-highlight-4 .ixbrl-sub-element:not(.ixbrl-no-highlight),
-  &.ixbrl-highlight-5 .ixbrl-sub-element:not(.ixbrl-no-highlight) {
+.review.ixbrl-highlight-all {
+  .ixbrl-element:not(.ixbrl-no-highlight),
+  .ixbrl-sub-element:not(.ixbrl-no-highlight) {
     background-color: var(--colour-highlight-default) !important; // Override inline styles
   }
 


### PR DESCRIPTION
#### Reason for change

An internal report took over 60 seconds to complete highlight all. Its thousands of continuation fragments caused many class mutations. These changes reduce the highlight step from 60+ seconds to under 100 ms.

#### Description of change

* Prepare node level highlight classes once, then toggle highlighting with a report body class.
* Skip namespace specific node classes in review mode, where tagged facts use one color. In review mode other colors are used to distinguish between tagged and untagged content instead of tagged namespaces.
* Process shared fact and continuation nodes only once.

#### Steps to Test

* Verify review mode highlight all preserves default color for tagged facts.
* Verify non-review highlight all preserves namespace specific colors.
* Verify continuation fragments highlight correctly in both modes.

**review**:
@Arelle/arelle
@paulwarren-wk
