### PR TITLE
Wrap empty inline XBRL elements

### DIFF
--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -128,7 +128,9 @@ export class Viewer {
     // children, use those nodes as the wrappers.
     //
     // Otherwise, insert a wrapper node around the element.  If the node or any
-    // descendent has display: block, a div is used, otherwise a span.  
+    // descendent has display: block, a div is used, otherwise a span.  This
+    // includes elements with no content at all (e.g. nil facts), which would
+    // otherwise have no wrapper and so could not be highlighted or located.
     //
     // We want to avoid adding wrapper nodes around inline-block children, as
     // wrapping in block or inline-block can interfere with layout (e.g. some
@@ -137,7 +139,10 @@ export class Viewer {
     // Returns an array of the chosen nodes as DOM nodes.
     //
     _wrapNode(n) {
-        if (Array.from(n.childNodes).some(n => n.nodeType === Node.TEXT_NODE && !/^\s*$/.test(n.nodeValue) )) {
+        const childNodes = Array.from(n.childNodes);
+        const elementChildren = childNodes.filter(n => n.nodeType === Node.ELEMENT_NODE);
+        const hasText = childNodes.some(n => n.nodeType === Node.TEXT_NODE && !/^\s*$/.test(n.nodeValue));
+        if (hasText || elementChildren.length === 0) {
             let wrapper = "<span>";
             if (getComputedStyle(n).getPropertyValue("display") === "block") {
                 wrapper = '<div>';
@@ -155,7 +160,7 @@ export class Viewer {
             return [n.parentNode];
         }
         else {
-            return Array.from(n.childNodes).filter(n => n.nodeType === Node.ELEMENT_NODE);
+            return elementChildren;
         }
     }
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -288,7 +288,7 @@ export class Viewer {
         const tableNode = domNode.closest("td,th");
         let nodes;
         const innerText = $(domNode).text();
-        if (tableNode !== null && getComputedStyle(tableNode).display === 'table-cell' && innerText.length > 0) {
+        if (tableNode !== null && getComputedStyle(tableNode).display === 'table-cell') {
             // Use indexOf rather than a single regex because innerText may
             // be too long for the regex engine 
             const outerText = $(tableNode).text();

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.js
@@ -157,6 +157,9 @@ export class Viewer {
                 }
             }
             $(n).wrap(wrapper);
+            if (!hasText) {
+                n.parentNode.classList.add("ixbrl-no-content");
+            }
             return [n.parentNode];
         }
         else {
@@ -401,8 +404,14 @@ export class Viewer {
     //   .ixbrl-element-hidden an ix: element inside ix:hidden
     //
     // Additional classes:
-    //   .ixbrl-no-highlight   a zero-height .ixbrl-element - no highlighting or 
-    //                         borders applied
+    //   .ixbrl-no-highlight   a zero-height .ixbrl-element whose content is
+    //                         absolutely positioned and highlighted via
+    //                         .ixbrl-sub-element - no highlighting or borders
+    //                         applied to the wrapper itself
+    //   .ixbrl-no-content     a wrapper inserted around an element with no
+    //                         content (e.g. a nil fact), so there is nothing
+    //                         else to highlight - given a marker so that it
+    //                         can be seen and clicked
     //   .ixbrl-element-nonfraction,
     //   .ixbrl-element-nonnumeric,
     //   .ixbrl-continuation, 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -319,9 +319,21 @@ describe("_findOrCreateWrapperNode", () => {
         expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
     });
 
-    test("wraps an empty element that is the only content of a table cell", () => {
+    test("uses the table cell as the wrapper for an empty element that is its only content", () => {
         const { viewer, doc } = makeHighlightViewer(false);
-        const ixElement = appendIXElement(doc, '<table><tr><td><ix:nonFraction id="f1"></ix:nonFraction></td></tr></table>');
+        const ixElement = appendIXElement(doc, '<table><tr><td>$ <ix:nonFraction id="f1"></ix:nonFraction></td></tr></table>');
+
+        const nodes = viewer._findOrCreateWrapperNode(ixElement, false);
+
+        expect(nodes.length).toBe(1);
+        expect(nodes.get(0)).toBe(ixElement.parentNode);
+        expect(nodes.get(0).tagName).toBe("TD");
+        expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+    });
+
+    test("wraps an empty element in a table cell with other content", () => {
+        const { viewer, doc } = makeHighlightViewer(false);
+        const ixElement = appendIXElement(doc, '<table><tr><td>Cash: <ix:nonFraction id="f1"></ix:nonFraction></td></tr></table>');
 
         const nodes = viewer._findOrCreateWrapperNode(ixElement, false);
 

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -293,6 +293,7 @@ describe("_findOrCreateWrapperNode", () => {
         expect(nodes.get(0)).toBe(ixElement.parentNode);
         expect(nodes.get(0).tagName).toBe("SPAN");
         expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+        expect(nodes.get(0).classList.contains("ixbrl-no-content")).toBe(false);
     });
 
     test("uses element children of an element with no text as wrappers", () => {
@@ -317,6 +318,7 @@ describe("_findOrCreateWrapperNode", () => {
         expect(nodes.get(0)).toBe(ixElement.parentNode);
         expect(nodes.get(0).tagName).toBe("SPAN");
         expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+        expect(nodes.get(0).classList.contains("ixbrl-no-content")).toBe(true);
     });
 
     test("uses the table cell as the wrapper for an empty element that is its only content", () => {
@@ -329,6 +331,7 @@ describe("_findOrCreateWrapperNode", () => {
         expect(nodes.get(0)).toBe(ixElement.parentNode);
         expect(nodes.get(0).tagName).toBe("TD");
         expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+        expect(nodes.get(0).classList.contains("ixbrl-no-content")).toBe(false);
     });
 
     test("wraps an empty element in a table cell with other content", () => {
@@ -341,5 +344,6 @@ describe("_findOrCreateWrapperNode", () => {
         expect(nodes.get(0)).toBe(ixElement.parentNode);
         expect(nodes.get(0).tagName).toBe("SPAN");
         expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+        expect(nodes.get(0).classList.contains("ixbrl-no-content")).toBe(true);
     });
 });

--- a/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
+++ b/iXBRLViewerPlugin/viewer/src/js/viewer.test.js
@@ -270,3 +270,64 @@ describe("highlightAllTags", () => {
         expect(element.classList.contains("ixbrl-highlight-1")).toBe(false);
     });
 });
+
+describe("_findOrCreateWrapperNode", () => {
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    function appendIXElement(doc, html) {
+        const container = doc.createElement("div");
+        container.innerHTML = html;
+        doc.body.appendChild(container);
+        return container.querySelector("[id]");
+    }
+
+    test("wraps an element containing text", () => {
+        const { viewer, doc } = makeHighlightViewer(false);
+        const ixElement = appendIXElement(doc, '<span>Cash: <ix:nonFraction id="f1">123</ix:nonFraction></span>');
+
+        const nodes = viewer._findOrCreateWrapperNode(ixElement, false);
+
+        expect(nodes.length).toBe(1);
+        expect(nodes.get(0)).toBe(ixElement.parentNode);
+        expect(nodes.get(0).tagName).toBe("SPAN");
+        expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+    });
+
+    test("uses element children of an element with no text as wrappers", () => {
+        const { viewer, doc } = makeHighlightViewer(false);
+        const ixElement = appendIXElement(doc, '<ix:nonNumeric id="f1"> <p>A</p> <p>B</p> </ix:nonNumeric>');
+
+        const nodes = viewer._findOrCreateWrapperNode(ixElement, false);
+
+        expect(nodes.length).toBe(2);
+        expect(nodes.get(0)).toBe(ixElement.children[0]);
+        expect(nodes.get(1)).toBe(ixElement.children[1]);
+        expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+    });
+
+    test("wraps an empty element", () => {
+        const { viewer, doc } = makeHighlightViewer(false);
+        const ixElement = appendIXElement(doc, '<span>nil &gt; <ix:nonFraction id="f1"></ix:nonFraction> &lt; nil</span>');
+
+        const nodes = viewer._findOrCreateWrapperNode(ixElement, false);
+
+        expect(nodes.length).toBe(1);
+        expect(nodes.get(0)).toBe(ixElement.parentNode);
+        expect(nodes.get(0).tagName).toBe("SPAN");
+        expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+    });
+
+    test("wraps an empty element that is the only content of a table cell", () => {
+        const { viewer, doc } = makeHighlightViewer(false);
+        const ixElement = appendIXElement(doc, '<table><tr><td><ix:nonFraction id="f1"></ix:nonFraction></td></tr></table>');
+
+        const nodes = viewer._findOrCreateWrapperNode(ixElement, false);
+
+        expect(nodes.length).toBe(1);
+        expect(nodes.get(0)).toBe(ixElement.parentNode);
+        expect(nodes.get(0).tagName).toBe("SPAN");
+        expect(nodes.get(0).classList.contains("ixbrl-element")).toBe(true);
+    });
+});

--- a/iXBRLViewerPlugin/viewer/src/less/viewer.less
+++ b/iXBRLViewerPlugin/viewer/src/less/viewer.less
@@ -130,6 +130,31 @@ body.ixbrl-highlight-all .ixbrl-highlight {
   }
 }
 
+// Empty elements (e.g. nil facts) have no content, so their wrapper has zero
+// width. The highlight background has no area, the outline collapses to a
+// hairline, and there is nothing to hover or click.  Push the outline out to
+// form a small box, and fill the box with an absolutely positioned
+// pseudo element.  The pseudo element takes no space in the document flow, so
+// the layout of the document is unchanged.  It inherits the wrapper's
+// highlight background, and provides the hit area for hover and click.
+@no-content-marker-inset: 0.2em;
+
+.ixbrl-no-content:not(.ixbrl-no-highlight) {
+  position: relative;
+
+  &::after {
+    content: "";
+    position: absolute;
+    inset: -@no-content-marker-inset;
+    background-color: inherit;
+  }
+
+  &,
+  &:hover {
+    outline-offset: @no-content-marker-inset;
+  }
+}
+
 div.ixbrl-table-handle {
   @export-handle-size: 0.4rem;
 


### PR DESCRIPTION
#### Reason for change

Nil iXBRL fact values cannot currently be highlighted or selected in the DOM.

| master | branch |
| -- | -- |
| <img width="725" height="595" alt="master" src="https://github.com/user-attachments/assets/69ea0b89-c4f3-4f1c-b891-125d999caf78" />  |  <img width="725" height="595" alt="branch" src="https://github.com/user-attachments/assets/823e0459-e45b-464d-861c-40f01746d09d" /> |

#### Description of change

Wrap empty elements, using the table cell when appropriate. Add unit tests for empty and nested elements.

#### Steps to Test

* CI

**review**:
@Arelle/arelle
@paulwarren-wk
